### PR TITLE
hotfixed getBinPosition assertion

### DIFF
--- a/mrmd/data/MultiHistogram.cpp
+++ b/mrmd/data/MultiHistogram.cpp
@@ -22,6 +22,17 @@ namespace mrmd
 {
 namespace data
 {
+
+ScalarView::HostMirror MultiHistogram::createGrid() const
+{
+    ScalarView::HostMirror grid("grid", numBins);
+    for (idx_t i = 0; i < numBins; ++i)
+    {
+        grid[i] = getBinPosition(i);
+    }
+    return grid;
+}
+
 MultiHistogram& MultiHistogram::operator+=(const MultiHistogram& rhs)
 {
     if (numBins != rhs.numBins) exit(EXIT_FAILURE);

--- a/mrmd/data/MultiHistogram.hpp
+++ b/mrmd/data/MultiHistogram.hpp
@@ -56,7 +56,7 @@ struct MultiHistogram
      */
     KOKKOS_INLINE_FUNCTION idx_t getBin(const real_t& val) const
     {
-        auto bin = idx_c((val - min) * inverseBinSize);
+        auto bin = idx_c(std::floor((val - min) * inverseBinSize));
         if (bin < 0) bin = -1;
         if (bin >= numBins) bin = -1;
         return bin;

--- a/mrmd/data/MultiHistogram.hpp
+++ b/mrmd/data/MultiHistogram.hpp
@@ -70,15 +70,7 @@ struct MultiHistogram
         return binPosition;
     }
 
-    ScalarView::HostMirror createGrid() const
-    {
-        ScalarView::HostMirror grid("grid", numBins);
-        for (idx_t i = 0; i < numBins; ++i)
-        {
-            grid[i] = getBinPosition(i);
-        }
-        return grid;
-    }
+    ScalarView::HostMirror createGrid() const;
 
     const real_t min;
     const real_t max;

--- a/mrmd/data/MultiHistogram.hpp
+++ b/mrmd/data/MultiHistogram.hpp
@@ -64,8 +64,8 @@ struct MultiHistogram
 
     KOKKOS_INLINE_FUNCTION real_t getBinPosition(idx_t binIdx) const
     {
-        assert(binIdx < 0);
-        assert(binIdx >= numBins);
+        assert(binIdx >= 0);
+        assert(binIdx < numBins);
         auto binPosition = min + (real_c(binIdx) + 0.5_r) * binSize;
         return binPosition;
     }

--- a/mrmd/data/MultiHistogram.test.cpp
+++ b/mrmd/data/MultiHistogram.test.cpp
@@ -21,6 +21,15 @@ namespace mrmd
 namespace data
 {
 
+TEST(MultiHistogram, getBin)
+{
+    MultiHistogram histogram("histogram", 0_r, 10_r, 10, 2);
+    EXPECT_EQ(histogram.getBin(-0.5_r), -1);
+    EXPECT_EQ(histogram.getBin(0.5_r), 0);
+    EXPECT_EQ(histogram.getBin(5.5_r), 5);
+    EXPECT_EQ(histogram.getBin(10.5_r), -1);
+}
+
 TEST(MultiHistogram, getBinPosition)
 {
     MultiHistogram histogram("histogram", 0_r, 10_r, 10, 2);

--- a/mrmd/data/MultiHistogram.test.cpp
+++ b/mrmd/data/MultiHistogram.test.cpp
@@ -21,6 +21,13 @@ namespace mrmd
 namespace data
 {
 
+TEST(MultiHistogram, getBinPosition)
+{
+    MultiHistogram histogram("histogram", 0_r, 10_r, 10, 2);
+    EXPECT_FLOAT_EQ(histogram.getBinPosition(0), 0.5_r);
+    EXPECT_FLOAT_EQ(histogram.getBinPosition(5), 5.5_r);
+}
+
 TEST(MultiHistogram, scale)
 {
     MultiHistogram histogram("histogram", 0_r, 10_r, 11, 2);


### PR DESCRIPTION
The two lines that have been corrected now are supposed to assert that the given `binIdx` IS actually among the bin indices for which data has been stored. Before, they asserted the opposite and hence interrupted the program wrongly.