### PR TITLE
Implement counting of particle fluxes

### DIFF
--- a/mrmd/action/VelocityVerletLangevinThermostat.cpp
+++ b/mrmd/action/VelocityVerletLangevinThermostat.cpp
@@ -83,6 +83,101 @@ real_t VelocityVerletLangevinThermostat::preForceIntegrate(data::Atoms& atoms, c
     return std::sqrt(maxDistSqr);
 }
 
+std::tuple<real_t, idx_t, idx_t> VelocityVerletLangevinThermostat::preForceIntegrate(data::Atoms& atoms, const real_t dt, const real_t fluxBoundaryLeft, const real_t fluxBoundaryRight)
+{
+    auto RNG = randPool_;
+    auto pos = atoms.getPos();
+    auto vel = atoms.getVel();
+    auto force = atoms.getForce();
+    auto mass = atoms.getMass();
+    auto zeta = zeta_;
+    auto temperature = temperature_;
+
+    auto policy = Kokkos::RangePolicy<>(0, atoms.numLocalAtoms);
+    auto kernel = KOKKOS_LAMBDA(const idx_t& idx, real_t& maxDistSqr, idx_t& fluxLeft, idx_t& fluxRight)
+    {
+        real_t dx[3];
+        dx[0] = pos(idx, 0);
+        dx[1] = pos(idx, 1);
+        dx[2] = pos(idx, 2);
+
+        auto dtm = dt / mass(idx);
+        vel(idx, 0) += 0.5_r * dtm * force(idx, 0);
+        vel(idx, 1) += 0.5_r * dtm * force(idx, 1);
+        vel(idx, 2) += 0.5_r * dtm * force(idx, 2);
+
+        pos(idx, 0) += 0.5_r * dt * vel(idx, 0);
+        pos(idx, 1) += 0.5_r * dt * vel(idx, 1);
+        pos(idx, 2) += 0.5_r * dt * vel(idx, 2);
+
+        auto damping = std::exp(-zeta * dtm);
+        vel(idx, 0) *= damping;
+        vel(idx, 1) *= damping;
+        vel(idx, 2) *= damping;
+
+        auto sigma = std::sqrt(temperature / mass(idx) * (1_r - std::exp(-2_r * zeta * dtm)));
+        // Get a random number state from the pool for the active thread
+        auto randGen = RNG.get_state();
+
+        vel(idx, 0) += sigma * randGen.normal();
+        vel(idx, 1) += sigma * randGen.normal();
+        vel(idx, 2) += sigma * randGen.normal();
+
+        // Give the state back, which will allow another thread to acquire it
+        RNG.free_state(randGen);
+
+        pos(idx, 0) += 0.5_r * dt * vel(idx, 0);
+        pos(idx, 1) += 0.5_r * dt * vel(idx, 1);
+        pos(idx, 2) += 0.5_r * dt * vel(idx, 2);
+
+        if (dx[0] < fluxBoundaryLeft && pos(idx, 0) >= fluxBoundaryLeft)
+        {
+            // particle entered system from the left
+            ++fluxLeft;
+        }
+        if (dx[0] >= fluxBoundaryLeft && pos(idx, 0) < fluxBoundaryLeft)
+        {
+            // particle left system to the left
+            --fluxLeft;
+        }
+        if (dx[0] > fluxBoundaryRight && pos(idx, 0) <= fluxBoundaryRight)
+        {
+            // particle entered system from the right
+            ++fluxRight;
+        }
+        if (dx[0] <= fluxBoundaryRight && pos(idx, 0) > fluxBoundaryRight)
+        {
+            // particle left system to the right
+            --fluxRight;
+        }
+
+        dx[0] -= pos(idx, 0);
+        dx[1] -= pos(idx, 1);
+        dx[2] -= pos(idx, 2);
+
+        auto distSqr = util::dot3(dx, dx);
+        if (distSqr > maxDistSqr) maxDistSqr = distSqr;
+    };
+    real_t maxDistSqr = 0_r;
+    idx_t fluxLeft = 0;
+    idx_t fluxRight = 0;
+
+    Kokkos::parallel_reduce("VelocityVerletLangevinThermostat::preForceIntegrate",
+                            policy,
+                            kernel,
+                            Kokkos::Max<real_t>(maxDistSqr), 
+                            Kokkos::Sum<idx_t>(fluxLeft),
+                            Kokkos::Sum<idx_t>(fluxRight));
+    Kokkos::fence();
+
+    std::tuple<real_t, idx_t, idx_t> result;
+    std::get<0>(result) = std::sqrt(maxDistSqr);
+    std::get<1>(result) = fluxLeft;
+    std::get<2>(result) = fluxRight;
+    
+    return result;
+}
+
 void VelocityVerletLangevinThermostat::postForceIntegrate(data::Atoms& atoms, const real_t dt)
 {
     auto dtf = 0.5_r * dt;

--- a/mrmd/action/VelocityVerletLangevinThermostat.cpp
+++ b/mrmd/action/VelocityVerletLangevinThermostat.cpp
@@ -83,7 +83,11 @@ real_t VelocityVerletLangevinThermostat::preForceIntegrate(data::Atoms& atoms, c
     return std::sqrt(maxDistSqr);
 }
 
-std::tuple<real_t, idx_t, idx_t> VelocityVerletLangevinThermostat::preForceIntegrate(data::Atoms& atoms, const real_t dt, const real_t fluxBoundaryLeft, const real_t fluxBoundaryRight)
+std::tuple<real_t, idx_t, idx_t> VelocityVerletLangevinThermostat::preForceIntegrate(
+    data::Atoms& atoms,
+    const real_t dt,
+    const real_t fluxBoundaryLeft,
+    const real_t fluxBoundaryRight)
 {
     auto RNG = randPool_;
     auto pos = atoms.getPos();
@@ -94,7 +98,8 @@ std::tuple<real_t, idx_t, idx_t> VelocityVerletLangevinThermostat::preForceInteg
     auto temperature = temperature_;
 
     auto policy = Kokkos::RangePolicy<>(0, atoms.numLocalAtoms);
-    auto kernel = KOKKOS_LAMBDA(const idx_t& idx, real_t& maxDistSqr, idx_t& fluxLeft, idx_t& fluxRight)
+    auto kernel =
+        KOKKOS_LAMBDA(const idx_t& idx, real_t& maxDistSqr, idx_t& fluxLeft, idx_t& fluxRight)
     {
         real_t dx[3];
         dx[0] = pos(idx, 0);
@@ -165,7 +170,7 @@ std::tuple<real_t, idx_t, idx_t> VelocityVerletLangevinThermostat::preForceInteg
     Kokkos::parallel_reduce("VelocityVerletLangevinThermostat::preForceIntegrate",
                             policy,
                             kernel,
-                            Kokkos::Max<real_t>(maxDistSqr), 
+                            Kokkos::Max<real_t>(maxDistSqr),
                             Kokkos::Sum<idx_t>(fluxLeft),
                             Kokkos::Sum<idx_t>(fluxRight));
     Kokkos::fence();
@@ -174,7 +179,7 @@ std::tuple<real_t, idx_t, idx_t> VelocityVerletLangevinThermostat::preForceInteg
     std::get<0>(result) = std::sqrt(maxDistSqr);
     std::get<1>(result) = fluxLeft;
     std::get<2>(result) = fluxRight;
-    
+
     return result;
 }
 

--- a/mrmd/action/VelocityVerletLangevinThermostat.hpp
+++ b/mrmd/action/VelocityVerletLangevinThermostat.hpp
@@ -43,7 +43,10 @@ public:
     }
 
     real_t preForceIntegrate(data::Atoms& atoms, const real_t dt);
-    std::tuple<real_t, idx_t, idx_t> preForceIntegrate(data::Atoms& atoms, const real_t dt, const real_t fluxBoundaryLeft, const real_t fluxBoundaryRight);
+    std::tuple<real_t, idx_t, idx_t> preForceIntegrate(data::Atoms& atoms,
+                                                       const real_t dt,
+                                                       const real_t fluxBoundaryLeft,
+                                                       const real_t fluxBoundaryRight);
     void postForceIntegrate(data::Atoms& atoms, const real_t dt);
 };
 }  // namespace action

--- a/mrmd/action/VelocityVerletLangevinThermostat.hpp
+++ b/mrmd/action/VelocityVerletLangevinThermostat.hpp
@@ -43,6 +43,7 @@ public:
     }
 
     real_t preForceIntegrate(data::Atoms& atoms, const real_t dt);
+    std::tuple<real_t, idx_t, idx_t> preForceIntegrate(data::Atoms& atoms, const real_t dt, const real_t fluxBoundaryLeft, const real_t fluxBoundaryRight);
     void postForceIntegrate(data::Atoms& atoms, const real_t dt);
 };
 }  // namespace action


### PR DESCRIPTION
Solves #50.

I implemented the particle flux counting within the integrator, which is far from optimal due to the following two points:

1. This intertwines analysis and core functionality. It would be much more desirable to have it as a separate module within the `analysis` directory. However, counting the number of particles crossing the two boundaries _after_ the integration step could triple the computational effort in the worst case. 
2. It would be preferable on physical grounds to count the number of _molecules_ crossing the boundaries, so maybe one should also consider implementing the counting within the `updateMolecules` function.   

All in all, I'd be happy about any input regarding the software design here. 