### PR TITLE
Update interpolation input and output handling

### DIFF
--- a/mrmd/assert/verbose.hpp
+++ b/mrmd/assert/verbose.hpp
@@ -92,12 +92,6 @@ std::string generateAssertionMessage(const T& lhs,
         assumption::log(ss.str()); \
     }
 
-template <typename FLOAT>
-bool isFloatEqual(const FLOAT& lhs, const FLOAT& rhs)
-{
-    return std::abs(lhs - rhs) < FLOAT(1e-10);
-}
-
 // macro overloading (-> https://stackoverflow.com/a/24028231)
 
 #define GLUE(x, y) x y

--- a/mrmd/datatypes.hpp
+++ b/mrmd/datatypes.hpp
@@ -125,6 +125,15 @@ KOKKOS_INLINE_FUNCTION constexpr float float_c(const T& val)
     return static_cast<float>(val);
 }
 
+template <typename FLOAT>
+KOKKOS_INLINE_FUNCTION bool isFloatEqual(
+    const FLOAT& lhs,
+    const FLOAT& rhs,
+    const FLOAT& epsilon = std::numeric_limits<FLOAT>::epsilon())
+{
+    return std::abs(lhs - rhs) < epsilon;
+}
+
 enum class AXIS : idx_t
 {
     X = 0,  ///< index of the x coordinate in vector views

--- a/mrmd/util/interpolation.cpp
+++ b/mrmd/util/interpolation.cpp
@@ -48,8 +48,6 @@ void updateInterpolate(const data::MultiHistogram& inputData, data::MultiHistogr
     };
     Kokkos::parallel_for("MultiHistogram::updateInterpolate", policy, kernel);
     Kokkos::fence();
-
-    return;
 }
 
 }  // namespace util

--- a/mrmd/util/interpolation.cpp
+++ b/mrmd/util/interpolation.cpp
@@ -18,7 +18,8 @@ namespace mrmd
 {
 namespace util
 {
-data::MultiHistogram interpolate(const data::MultiHistogram& inputCoarse, const data::MultiHistogram& inputFine)
+data::MultiHistogram interpolate(const data::MultiHistogram& inputCoarse,
+                                 const data::MultiHistogram& inputFine)
 {
     MRMD_HOST_ASSERT_EQUAL(inputFine.numHistograms, inputCoarse.numHistograms);
 
@@ -46,7 +47,8 @@ data::MultiHistogram interpolate(const data::MultiHistogram& inputCoarse, const 
         output.data(binIdx, histogramIdx) =
             lerp(inputDataLeft,
                  inputDataRight,
-                 (outputBinPosition - inputCoarse.getBinPosition(leftBinIdx)) * inputCoarse.inverseBinSize);
+                 (outputBinPosition - inputCoarse.getBinPosition(leftBinIdx)) *
+                     inputCoarse.inverseBinSize);
     };
     Kokkos::parallel_for("MultiHistogram::interpolate", policy, kernel);
     Kokkos::fence();

--- a/mrmd/util/interpolation.cpp
+++ b/mrmd/util/interpolation.cpp
@@ -31,7 +31,7 @@ void updateInterpolate(const data::MultiHistogram& target, const data::MultiHist
         idx_t leftBinIdx = input.getBin(outputBinPosition - 0.5_r * input.binSize);
         idx_t rightBinIdx = leftBinIdx + 1;
 
-        // only update if within bounds of input histogram or exactly at boundary
+        // only update if within bounds of input histogram
         if (leftBinIdx >= 0 && rightBinIdx < input.numBins)
         {
             auto inputLeft = input.data(leftBinIdx, histogramIdx);
@@ -41,14 +41,6 @@ void updateInterpolate(const data::MultiHistogram& target, const data::MultiHist
                 lerp(inputLeft,
                      inputRight,
                      (outputBinPosition - input.getBinPosition(leftBinIdx)) * input.inverseBinSize);
-        }
-        else if (isFloatEqual(outputBinPosition, input.getBinPosition(0)))
-        {
-            target.data(binIdx, histogramIdx) += input.data(0, histogramIdx);
-        }
-        else if (isFloatEqual(outputBinPosition, input.getBinPosition(input.numBins - 1)))
-        {
-            target.data(binIdx, histogramIdx) += input.data(input.numBins - 1, histogramIdx);
         }
     };
     Kokkos::parallel_for("MultiHistogram::updateInterpolate", policy, kernel);

--- a/mrmd/util/interpolation.cpp
+++ b/mrmd/util/interpolation.cpp
@@ -42,11 +42,11 @@ void updateInterpolate(const data::MultiHistogram& target, const data::MultiHist
                      inputRight,
                      (outputBinPosition - input.getBinPosition(leftBinIdx)) * input.inverseBinSize);
         }
-        else if (isFloatEQ(outputBinPosition, input.getBinPosition(0)))
+        else if (isFloatEqual(outputBinPosition, input.getBinPosition(0)))
         {
             target.data(binIdx, histogramIdx) += input.data(0, histogramIdx);
         }
-        else if (isFloatEQ(outputBinPosition, input.getBinPosition(input.numBins - 1)))
+        else if (isFloatEqual(outputBinPosition, input.getBinPosition(input.numBins - 1)))
         {
             target.data(binIdx, histogramIdx) += input.data(input.numBins - 1, histogramIdx);
         }

--- a/mrmd/util/interpolation.hpp
+++ b/mrmd/util/interpolation.hpp
@@ -35,14 +35,14 @@ real_t lerp(const real_t& left, const real_t& right, const real_t& factor)
 }
 
 /**
- * Linear interpolation of data contained in input MultiHistogram onto given grid.
- * Data for grid points outside of the grid range of the input MultiHistogram are set to zero.
- * @param inputCoarse input MultiHistogram containing data to interpolate on coarse grid.
- * @param inputFine MultiHistogram defining the grid to interpolate onto.
- * @return MultiHistogram containing interpolated data on given grid
+ * Linear interpolation of data contained in input MultiHistogram onto grid of target histogram,
+ * updating the data of target. Data for grid points outside of the grid range of the input
+ * MultiHistogram are set to zero.
+ * @param input input MultiHistogram containing data to interpolate on coarse grid.
+ * @param target MultiHistogram defining the grid to interpolate onto and containing the data
+ * to be updated by interpolating the data from input.
  */
-data::MultiHistogram interpolate(const data::MultiHistogram& inputCoarse,
-                                 const data::MultiHistogram& inputFine);
+void updateInterpolate(const data::MultiHistogram& input, data::MultiHistogram& target);
 
 }  // namespace util
 }  // namespace mrmd

--- a/mrmd/util/interpolation.hpp
+++ b/mrmd/util/interpolation.hpp
@@ -42,7 +42,7 @@ real_t lerp(const real_t& left, const real_t& right, const real_t& factor)
  * @param target MultiHistogram defining the grid to interpolate onto and containing the data
  * to be updated by interpolating the data from input.
  */
-void updateInterpolate(const data::MultiHistogram& input, data::MultiHistogram& target);
+void updateInterpolate(const data::MultiHistogram& target, const data::MultiHistogram& input);
 
 }  // namespace util
 }  // namespace mrmd

--- a/mrmd/util/interpolation.hpp
+++ b/mrmd/util/interpolation.hpp
@@ -37,11 +37,11 @@ real_t lerp(const real_t& left, const real_t& right, const real_t& factor)
 /**
  * Linear interpolation of data contained in input MultiHistogram onto given grid.
  * Data for grid points outside of the grid range of the input MultiHistogram are set to zero.
- * @param input input MultiHistogram containing data to interpolate
- * @param grid grid to interpolate data onto
+ * @param inputCoarse input MultiHistogram containing data to interpolate on coarse grid.
+ * @param inputFine MultiHistogram defining the grid to interpolate onto.
  * @return MultiHistogram containing interpolated data on given grid
  */
-data::MultiHistogram interpolate(const data::MultiHistogram& input, const ScalarView& grid);
+data::MultiHistogram interpolate(const data::MultiHistogram& inputCoarse, const data::MultiHistogram& inputFine);
 
 }  // namespace util
 }  // namespace mrmd

--- a/mrmd/util/interpolation.hpp
+++ b/mrmd/util/interpolation.hpp
@@ -41,7 +41,8 @@ real_t lerp(const real_t& left, const real_t& right, const real_t& factor)
  * @param inputFine MultiHistogram defining the grid to interpolate onto.
  * @return MultiHistogram containing interpolated data on given grid
  */
-data::MultiHistogram interpolate(const data::MultiHistogram& inputCoarse, const data::MultiHistogram& inputFine);
+data::MultiHistogram interpolate(const data::MultiHistogram& inputCoarse,
+                                 const data::MultiHistogram& inputFine);
 
 }  // namespace util
 }  // namespace mrmd

--- a/mrmd/util/interpolation.hpp
+++ b/mrmd/util/interpolation.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <limits>
+
 #include "data/MultiHistogram.hpp"
 #include "util/IsInSymmetricSlab.hpp"
 
@@ -32,6 +34,14 @@ KOKKOS_INLINE_FUNCTION
 real_t lerp(const real_t& left, const real_t& right, const real_t& factor)
 {
     return left + (right - left) * factor;
+}
+
+KOKKOS_INLINE_FUNCTION
+bool isFloatEQ(const real_t& a,
+               const real_t& b,
+               const real_t& epsilon = std::numeric_limits<real_t>::epsilon())
+{
+    return std::abs(a - b) <= epsilon;
 }
 
 /**

--- a/mrmd/util/interpolation.hpp
+++ b/mrmd/util/interpolation.hpp
@@ -46,9 +46,9 @@ bool isFloatEQ(const real_t& a,
 
 /**
  * Linear interpolation of data contained in input MultiHistogram onto grid of target histogram,
- * updating the data of target. Data for grid points outside of the grid range of the input
- * MultiHistogram are set to zero.
- * @param input input MultiHistogram containing data to interpolate on coarse grid.
+ * adding the interpolated data to the data already contained in target. Data for target grid points
+ * outside of the grid range of the input MultiHistogram is not updated.
+ * @param input MultiHistogram containing data to interpolate on coarse grid.
  * @param target MultiHistogram defining the grid to interpolate onto and containing the data
  * to be updated by interpolating the data from input.
  */

--- a/mrmd/util/interpolation.hpp
+++ b/mrmd/util/interpolation.hpp
@@ -36,14 +36,6 @@ real_t lerp(const real_t& left, const real_t& right, const real_t& factor)
     return left + (right - left) * factor;
 }
 
-KOKKOS_INLINE_FUNCTION
-bool isFloatEQ(const real_t& a,
-               const real_t& b,
-               const real_t& epsilon = std::numeric_limits<real_t>::epsilon())
-{
-    return std::abs(a - b) <= epsilon;
-}
-
 /**
  * Linear interpolation of data contained in input MultiHistogram onto grid of target histogram,
  * adding the interpolated data to the data already contained in target. Data for target grid points

--- a/mrmd/util/interpolation.test.cpp
+++ b/mrmd/util/interpolation.test.cpp
@@ -24,36 +24,45 @@ namespace util
 {
 TEST(interpolate, testInterpolate)
 {
-    data::MultiHistogram histogramData("histogramData", 0_r, 10_r, 10, 3);
+    data::MultiHistogram histogramInput("histogramInput", 0_r, 10_r, 10, 3);
     data::MultiHistogram histogramTarget("histogramTarget", 0.5_r, 9.5_r, 30, 3);
+    data::MultiHistogram histogramRef("histogramRef", histogramTarget);
 
-    auto h_dataCoarse = Kokkos::create_mirror_view(histogramData.data);
+    auto h_dataInput = Kokkos::create_mirror_view(histogramInput.data);
     for (auto idx = 0; idx < 10; ++idx)
     {
-        h_dataCoarse(idx, 0) = 0_r;
-        h_dataCoarse(idx, 1) = 1_r;
-        h_dataCoarse(idx, 2) = histogramData.getBinPosition(idx);
+        h_dataInput(idx, 0) = 0_r;
+        h_dataInput(idx, 1) = 1_r;
+        h_dataInput(idx, 2) = histogramInput.getBinPosition(idx);
     }
-    Kokkos::deep_copy(histogramData.data, h_dataCoarse);
+    Kokkos::deep_copy(histogramInput.data, h_dataInput);
 
-    auto h_dataFine = Kokkos::create_mirror_view(histogramTarget.data);
+    auto h_dataTarget = Kokkos::create_mirror_view(histogramTarget.data);
     for (auto idx = 0; idx < 30; ++idx)
     {
-        h_dataFine(idx, 0) = 0_r;
-        h_dataFine(idx, 1) = 1_r;
-        h_dataFine(idx, 2) = histogramTarget.getBinPosition(idx);
+        h_dataTarget(idx, 0) = 0_r;
+        h_dataTarget(idx, 1) = 0_r;
+        h_dataTarget(idx, 2) = 0_r;
     }
-    Kokkos::deep_copy(histogramTarget.data, h_dataFine);
+    Kokkos::deep_copy(histogramTarget.data, h_dataTarget);
 
-    util::updateInterpolate(histogramData, histogramTarget);
-    auto h_dataInterp =
-        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), histogramTarget.data);
+    auto h_dataRef = Kokkos::create_mirror_view(histogramRef.data);
+    for (auto idx = 0; idx < 30; ++idx)
+    {
+        h_dataRef(idx, 0) = 0_r;
+        h_dataRef(idx, 1) = 1_r;
+        h_dataRef(idx, 2) = histogramTarget.getBinPosition(idx);
+    }
+    Kokkos::deep_copy(histogramRef.data, h_dataRef);
+
+    util::updateInterpolate(histogramInput, histogramTarget);
+    h_dataTarget = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), histogramTarget.data);
 
     for (auto idx = 0; idx < 30; ++idx)
     {
-        EXPECT_FLOAT_EQ(h_dataFine(idx, 0), h_dataInterp(idx, 0));
-        EXPECT_FLOAT_EQ(h_dataFine(idx, 1), h_dataInterp(idx, 1));
-        EXPECT_FLOAT_EQ(h_dataFine(idx, 2), h_dataInterp(idx, 2));
+        EXPECT_FLOAT_EQ(h_dataTarget(idx, 0), h_dataRef(idx, 0));
+        EXPECT_FLOAT_EQ(h_dataTarget(idx, 1), h_dataRef(idx, 1));
+        EXPECT_FLOAT_EQ(h_dataTarget(idx, 2), h_dataRef(idx, 2));
     }
 }
 

--- a/mrmd/util/interpolation.test.cpp
+++ b/mrmd/util/interpolation.test.cpp
@@ -45,7 +45,7 @@ TEST(interpolate, testInterpolate)
     }
     Kokkos::deep_copy(histogramFine.data, h_dataFine);
 
-    auto histogramInterp = util::interpolate(histogramCoarse, createGrid(histogramFine));
+    auto histogramInterp = util::interpolate(histogramCoarse, histogramFine);
     auto h_dataInterp =
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), histogramInterp.data);
 

--- a/mrmd/util/interpolation.test.cpp
+++ b/mrmd/util/interpolation.test.cpp
@@ -55,7 +55,7 @@ TEST(interpolate, testInterpolate)
     }
     Kokkos::deep_copy(histogramRef.data, h_dataRef);
 
-    util::updateInterpolate(histogramInput, histogramTarget);
+    util::updateInterpolate(histogramTarget, histogramInput);
     h_dataTarget = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), histogramTarget.data);
 
     for (auto idx = 0; idx < 30; ++idx)

--- a/mrmd/util/interpolation.test.cpp
+++ b/mrmd/util/interpolation.test.cpp
@@ -22,7 +22,7 @@ namespace mrmd
 {
 namespace util
 {
-TEST(interpolate, testInterpolate)
+TEST(interpolate, preZeroInner)
 {
     data::MultiHistogram histogramInput("histogramInput", 0_r, 10_r, 10, 3);
     data::MultiHistogram histogramTarget("histogramTarget", 0.5_r, 9.5_r, 30, 3);
@@ -51,7 +51,61 @@ TEST(interpolate, testInterpolate)
     {
         h_dataRef(idx, 0) = 0_r;
         h_dataRef(idx, 1) = 1_r;
-        h_dataRef(idx, 2) = histogramTarget.getBinPosition(idx);
+        h_dataRef(idx, 2) = histogramRef.getBinPosition(idx);
+    }
+    Kokkos::deep_copy(histogramRef.data, h_dataRef);
+
+    util::updateInterpolate(histogramTarget, histogramInput);
+    h_dataTarget = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), histogramTarget.data);
+
+    for (auto idx = 0; idx < 30; ++idx)
+    {
+        EXPECT_FLOAT_EQ(h_dataTarget(idx, 0), h_dataRef(idx, 0));
+        EXPECT_FLOAT_EQ(h_dataTarget(idx, 1), h_dataRef(idx, 1));
+        EXPECT_FLOAT_EQ(h_dataTarget(idx, 2), h_dataRef(idx, 2));
+    }
+}
+
+TEST(interpolate, nonZeroWithBoundary)
+{
+    data::MultiHistogram histogramInput("histogramInput", 0_r, 10_r, 10, 3);
+    data::MultiHistogram histogramTarget("histogramTarget", 0_r, 10_r, 30, 3);
+    data::MultiHistogram histogramRef("histogramRef", histogramTarget);
+
+    auto h_dataInput = Kokkos::create_mirror_view(histogramInput.data);
+    for (auto idx = 0; idx < 10; ++idx)
+    {
+        h_dataInput(idx, 0) = 0_r;
+        h_dataInput(idx, 1) = 1_r;
+        h_dataInput(idx, 2) = histogramInput.getBinPosition(idx);
+    }
+    Kokkos::deep_copy(histogramInput.data, h_dataInput);
+
+    auto h_dataTarget = Kokkos::create_mirror_view(histogramTarget.data);
+    for (auto idx = 0; idx < 30; ++idx)
+    {
+        h_dataTarget(idx, 0) = 1_r;
+        h_dataTarget(idx, 1) = 1_r;
+        h_dataTarget(idx, 2) = 1_r;
+    }
+    Kokkos::deep_copy(histogramTarget.data, h_dataTarget);
+
+    auto h_dataRef = Kokkos::create_mirror_view(histogramRef.data);
+    for (auto idx = 0; idx < 30; ++idx)
+    {
+        if (histogramRef.getBinPosition(idx) >= histogramInput.getBinPosition(0) &&
+            histogramRef.getBinPosition(idx) <= histogramInput.getBinPosition(9))
+        {
+            h_dataRef(idx, 0) = 1_r + 0_r;
+            h_dataRef(idx, 1) = 1_r + 1_r;
+            h_dataRef(idx, 2) = 1_r + histogramRef.getBinPosition(idx);
+        }
+        else
+        {
+            h_dataRef(idx, 0) = 1_r + 0_r;
+            h_dataRef(idx, 1) = 1_r + 0_r;
+            h_dataRef(idx, 2) = 1_r + 0_r;
+        }
     }
     Kokkos::deep_copy(histogramRef.data, h_dataRef);
 

--- a/mrmd/util/interpolation.test.cpp
+++ b/mrmd/util/interpolation.test.cpp
@@ -24,30 +24,30 @@ namespace util
 {
 TEST(interpolate, testInterpolate)
 {
-    data::MultiHistogram histogramCoarse("histogram", 0_r, 10_r, 10, 3);
-    data::MultiHistogram histogramFine("histogram", 0.5_r, 9.5_r, 30, 3);
+    data::MultiHistogram histogramData("histogramData", 0_r, 10_r, 10, 3);
+    data::MultiHistogram histogramTarget("histogramTarget", 0.5_r, 9.5_r, 30, 3);
 
-    auto h_dataCoarse = Kokkos::create_mirror_view(histogramCoarse.data);
+    auto h_dataCoarse = Kokkos::create_mirror_view(histogramData.data);
     for (auto idx = 0; idx < 10; ++idx)
     {
         h_dataCoarse(idx, 0) = 0_r;
         h_dataCoarse(idx, 1) = 1_r;
-        h_dataCoarse(idx, 2) = histogramCoarse.getBinPosition(idx);
+        h_dataCoarse(idx, 2) = histogramData.getBinPosition(idx);
     }
-    Kokkos::deep_copy(histogramCoarse.data, h_dataCoarse);
+    Kokkos::deep_copy(histogramData.data, h_dataCoarse);
 
-    auto h_dataFine = Kokkos::create_mirror_view(histogramFine.data);
+    auto h_dataFine = Kokkos::create_mirror_view(histogramTarget.data);
     for (auto idx = 0; idx < 30; ++idx)
     {
         h_dataFine(idx, 0) = 0_r;
         h_dataFine(idx, 1) = 1_r;
-        h_dataFine(idx, 2) = histogramFine.getBinPosition(idx);
+        h_dataFine(idx, 2) = histogramTarget.getBinPosition(idx);
     }
-    Kokkos::deep_copy(histogramFine.data, h_dataFine);
+    Kokkos::deep_copy(histogramTarget.data, h_dataFine);
 
-    auto histogramInterp = util::interpolate(histogramCoarse, histogramFine);
+    util::updateInterpolate(histogramData, histogramTarget);
     auto h_dataInterp =
-        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), histogramInterp.data);
+        Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), histogramTarget.data);
 
     for (auto idx = 0; idx < 30; ++idx)
     {

--- a/mrmd/util/interpolation.test.cpp
+++ b/mrmd/util/interpolation.test.cpp
@@ -94,7 +94,7 @@ TEST(interpolate, nonZeroWithBoundary)
     for (auto idx = 0; idx < 30; ++idx)
     {
         if (histogramRef.getBinPosition(idx) >= histogramInput.getBinPosition(0) &&
-            histogramRef.getBinPosition(idx) <= histogramInput.getBinPosition(9))
+            histogramRef.getBinPosition(idx) < histogramInput.getBinPosition(9))
         {
             h_dataRef(idx, 0) = 1_r + 0_r;
             h_dataRef(idx, 1) = 1_r + 1_r;


### PR DESCRIPTION
Part of #47.

Changed the interpolation function to `updateInterpolate`, which now updates the data on a given `target` MultiHistogram with interpolated data from `input` MultiHistogram. 