### PR TITLE
implemented tutorial for argon nve simulation

### DIFF
--- a/examples/00_IdealGas_NVE/00_IdealGas_NVE.cpp
+++ b/examples/00_IdealGas_NVE/00_IdealGas_NVE.cpp
@@ -41,7 +41,7 @@ void runIdealGas(const Config& config)
     auto subdomain = data::Subdomain({0_r, 0_r, 0_r}, {100_r, 100_r, 100_r}, 1_r);
 
     // initialize atoms randomly in the domain
-    auto atoms = util::fillDomainWithAtoms(subdomain, 100000, 1_r, 1_r);
+    auto atoms = util::fillRectangularDomainWithAtoms(subdomain, 100000, 1_r, 1_r);
 
     // set up ghost layer for periodic boundary conditions
     communication::GhostLayer ghostLayer;

--- a/examples/01_Argon_NVE/01_Argon_NVE.cpp
+++ b/examples/01_Argon_NVE/01_Argon_NVE.cpp
@@ -23,7 +23,6 @@
 #include <iostream>
 
 #include "Cabana_NeighborList.hpp"
-#include "action/BerendsenThermostat.hpp"
 #include "action/LangevinThermostat.hpp"
 #include "action/LennardJones.hpp"
 #include "action/LimitAcceleration.hpp"
@@ -186,8 +185,8 @@ void runSimulation(Config& config)
             auto systemMomentum = analysis::getSystemMomentum(atoms);
             auto T = (2_r / 3_r) * Ek;
             auto p = analysis::getPressure(atoms, subdomain);
-            msd =
-                meanSquareDisplacement.calc(atoms, subdomain) / (config.outputInterval * config.dt);
+            msd = meanSquareDisplacement.calc(atoms, subdomain) /
+                  (real_c(config.outputInterval) * config.dt);
             meanSquareDisplacement.reset(atoms);
 
             // print statistics to console

--- a/examples/01_Argon_NVE/01_Argon_NVE.cpp
+++ b/examples/01_Argon_NVE/01_Argon_NVE.cpp
@@ -1,0 +1,266 @@
+// Copyright 2024 Sebastian Eibl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <CLI/App.hpp>
+#include <CLI/Config.hpp>
+#include <CLI/Formatter.hpp>
+#include <Kokkos_Core.hpp>
+#include <algorithm>
+#include <format>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+
+#include "Cabana_NeighborList.hpp"
+#include "action/BerendsenThermostat.hpp"
+#include "action/LangevinThermostat.hpp"
+#include "action/LennardJones.hpp"
+#include "action/LimitAcceleration.hpp"
+#include "action/LimitVelocity.hpp"
+#include "action/VelocityVerlet.hpp"
+#include "analysis/KineticEnergy.hpp"
+#include "analysis/MeanSquareDisplacement.hpp"
+#include "analysis/Pressure.hpp"
+#include "analysis/SystemMomentum.hpp"
+#include "communication/GhostLayer.hpp"
+#include "data/Atoms.hpp"
+#include "data/Subdomain.hpp"
+#include "datatypes.hpp"
+#include "initialization.hpp"
+#include "util/EnvironmentVariables.hpp"
+#include "util/PrintTable.hpp"
+#include "util/simulationSetup.hpp"
+
+using namespace mrmd;
+
+/**
+ * Configuration for the Argon NVE example simulation.
+ */
+struct Config
+{
+    // simulation time parameters
+    idx_t nsteps = 400001;               ///< number of steps to simulate
+    static constexpr real_t dt = 0.002;  ///< time step size in reduced units
+
+    // interaction parameters
+    static constexpr real_t sigma =
+        1_r;  ///< distance at which LJ potential is zero in reduced units
+    static constexpr real_t epsilon = 1_r;  ///< energy well depth of LJ potential in reduced units
+    static constexpr real_t mass = 1_r;     ///< mass of one atom in reduced units
+    static constexpr real_t maxVelocity =
+        1_r;  ///< maximum initial velocity component in reduced units
+    static constexpr real_t r_cut = 2.5_r * sigma;  ///< cutoff radius for LJ potential
+    static constexpr real_t r_cap = 0.7_r * sigma;  ///< capping radius for LJ potential
+
+    // neighbor list parameters
+    static constexpr real_t skin = 0.1_r * sigma;           ///< skin thickness for neighbor list
+    static constexpr real_t neighborCutoff = r_cut + skin;  ///< cutoff radius for neighbor list
+    static constexpr real_t cell_ratio =
+        1_r;  ///< ratio of cell size on Cartesian grid to cutoff radius for neighbor list
+    static constexpr idx_t estimatedMaxNeighbors =
+        60;  ///< estimated maximum number of neighbors per atom
+
+    // system parameters
+    static constexpr idx_t numAtoms = 16 * 16 * 16;  ///< number of atoms in the simulation
+    real_t Lx = 20_r * sigma;                        ///< box edge length
+
+    // equilibration parameters
+    idx_t nstepsEq = 100000;  ///< number of equilibration steps
+    real_t temperature =
+        1.5_r;  ///< target temperature during equilibration for thermostat in reduced units
+    static constexpr real_t gamma = 0.04_r / dt;  ///< friction coefficient for Langevin thermostat
+
+    // output parameters
+    bool bOutput = true;                  ///< whether to output data files
+    idx_t outputInterval = -1;            ///< interval for data file output (-1: no output)
+    const std::string resName = "Argon";  ///< residue name for output files
+    const std::vector<std::string> typeNames = {"Ar"};  ///< atom type names for output files
+};
+
+void runSimulation(Config& config)
+{
+    // initialize simulation domain
+    auto subdomain =
+        data::Subdomain({0_r, 0_r, 0_r}, {config.Lx, config.Lx, config.Lx}, config.neighborCutoff);
+
+    // calculate volume of the simulation domain
+    const auto volume = subdomain.diameter[0] * subdomain.diameter[1] * subdomain.diameter[2];
+
+    // initialize atoms randomly in the domain
+    auto atoms =
+        util::fillDomainWithAtoms(subdomain, config.numAtoms, config.maxVelocity, config.mass);
+
+    // calculate and print initial density
+    auto rho = real_c(atoms.numLocalAtoms) / volume;
+    std::cout << "rho: " << rho << std::endl;
+
+    // set up ghost layer for periodic boundary conditions
+    communication::GhostLayer ghostLayer;
+
+    // set up neighbor list
+    HalfVerletList verletList;
+    real_t maxAtomDisplacement = std::numeric_limits<real_t>::max();
+    idx_t rebuildCounter = 0;
+
+    // set up interaction potential and force calculation and application
+    action::LennardJones LJ(config.r_cut, config.sigma, config.epsilon, config.r_cap);
+
+    // set up thermostat for temperature control during equilibration
+    action::LangevinThermostat langevinThermostat(config.gamma, config.temperature, config.dt);
+
+    // set up timer for runtime measurement
+    Kokkos::Timer timer;
+
+    // set up mean square displacement analysis
+    analysis::MeanSquareDisplacement meanSquareDisplacement;
+    meanSquareDisplacement.reset(atoms);
+    auto msd = 0_r;
+
+    // print table header for simulation statistics
+    util::printTable("step", "time", "T", "Ek", "E0", "E", "p", "msd", "Nlocal", "Nghost");
+    util::printTableSep("step", "time", "T", "Ek", "E0", "E", "p", "msd", "Nlocal", "Nghost");
+
+    // open statistics file for writing simulation statistics
+    std::ofstream fStat("statistics.txt");
+
+    // main simulation loop
+    for (auto step = 0; step < config.nsteps; ++step)
+    {
+        // integrate equations of motion - first half step (drift)
+        maxAtomDisplacement += action::VelocityVerlet::preForceIntegrate(atoms, config.dt);
+
+        // reinsert atoms that left the domain according to periodic boundary conditions
+        ghostLayer.exchangeRealAtoms(atoms, subdomain);
+
+        // create ghost atoms in the ghost layer beyond the periodic boundaries
+        ghostLayer.createGhostAtoms(atoms, subdomain);
+
+        // check if neighbor list needs to be rebuilt
+        if (maxAtomDisplacement >=
+            config.skin *
+                0.5_r)  // the condition is on half the skin thickness because in principle two
+                        // atoms may both move half the skin thickness towards each other
+        {
+            // reset displacement
+            maxAtomDisplacement = 0_r;
+
+            // rebuild neighbor list
+            verletList.build(atoms.getPos(),
+                             0,
+                             atoms.numLocalAtoms,
+                             config.neighborCutoff,
+                             config.cell_ratio,
+                             subdomain.minGhostCorner.data(),
+                             subdomain.maxGhostCorner.data(),
+                             config.estimatedMaxNeighbors);
+            ++rebuildCounter;
+        }
+
+        // reset forces to zero
+        auto force = atoms.getForce();
+        Cabana::deep_copy(force, 0_r);
+
+        // compute and apply forces
+        LJ.apply(atoms, verletList);
+
+        // contribute forces calculated on ghost atoms back to real atoms
+        ghostLayer.contributeBackGhostToReal(atoms);
+
+        // handle output and statistics
+        if (config.bOutput && (step % config.outputInterval == 0))
+        {
+            // calculate statistics
+            auto E0 = LJ.getEnergy() / real_c(atoms.numLocalAtoms);
+            auto Ek = analysis::getMeanKineticEnergy(atoms);
+            auto systemMomentum = analysis::getSystemMomentum(atoms);
+            auto T = (2_r / 3_r) * Ek;
+            auto p = analysis::getPressure(atoms, subdomain);
+            msd =
+                meanSquareDisplacement.calc(atoms, subdomain) / (config.outputInterval * config.dt);
+            meanSquareDisplacement.reset(atoms);
+
+            // print statistics to console
+            util::printTable(step,
+                             timer.seconds(),
+                             T,
+                             Ek,
+                             E0,
+                             E0 + Ek,
+                             p,
+                             msd,
+                             atoms.numLocalAtoms,
+                             atoms.numGhostAtoms);
+
+            // dump statistics to file
+            fStat << step << " " << timer.seconds() << " " << T << " " << Ek << " " << E0 << " "
+                  << E0 + Ek << " " << p << " " << msd << " " << atoms.numLocalAtoms << " "
+                  << atoms.numGhostAtoms << " " << std::endl;
+        }
+
+        // check if still during equilibration phase
+        if (step <= config.nstepsEq)
+        {
+            // apply Langevin thermostat for temperature control during equilibration
+            langevinThermostat.apply(atoms);
+        }
+
+        // integrate equations of motion - second half step (kick)
+        action::VelocityVerlet::postForceIntegrate(atoms, config.dt);
+    }
+
+    // close statistics file
+    fStat.close();
+    auto time = timer.seconds();
+    std::cout << time << std::endl;
+
+    // write performance data to file
+    auto cores = util::getEnvironmentVariable("OMP_NUM_THREADS");
+    std::ofstream fout("ecab.perf", std::ofstream::app);
+    fout << cores << ", " << time << ", " << atoms.numLocalAtoms << ", " << config.nsteps
+         << std::endl;
+    fout.close();
+}
+
+int main(int argc, char* argv[])  // NOLINT
+{
+    // initialize Kokkos and MPI environment
+    initialize(argc, argv);
+
+    // print Kokkos execution space
+    std::cout << "execution space: " << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
+
+    // initialize simulation configuration with command line interface
+    Config config;
+    CLI::App app{"Lennard Jones Fluid benchmark application"};
+    app.add_option("-n,--nsteps", config.nsteps, "total number of simulation steps");
+    app.add_option("-L,--length", config.Lx, "simulation box diameter");
+    app.add_option("-e,--numeq", config.nstepsEq, "number of equilibration steps");
+    app.add_option(
+        "-T,--temperature",
+        config.temperature,
+        "temperature of the Langevin thermostat (negative numbers deactivate the thermostat)");
+    app.add_option("-o,--output", config.outputInterval, "output interval");
+    CLI11_PARSE(app, argc, argv);
+
+    // reset output parameter if output interval is negative
+    if (config.outputInterval < 0) config.bOutput = false;
+
+    // set up, equilibrate in NVT and run production in NVE
+    runSimulation(config);
+
+    // finalize Kokkos and MPI environment
+    finalize();
+
+    return EXIT_SUCCESS;
+}

--- a/examples/01_Argon_NVE/01_Argon_NVE.cpp
+++ b/examples/01_Argon_NVE/01_Argon_NVE.cpp
@@ -97,8 +97,8 @@ void runLennardJones(Config& config)
     const auto volume = subdomain.diameter[0] * subdomain.diameter[1] * subdomain.diameter[2];
 
     // initialize atoms randomly in the domain
-    auto atoms =
-        util::fillDomainWithAtoms(subdomain, config.numAtoms, config.maxVelocity, config.mass);
+    auto atoms = util::fillRectangularDomainWithAtoms(
+        subdomain, config.numAtoms, config.maxVelocity, config.mass);
 
     // calculate and print initial density
     auto rho = real_c(atoms.numLocalAtoms) / volume;

--- a/examples/01_Argon_NVE/01_Argon_NVE.cpp
+++ b/examples/01_Argon_NVE/01_Argon_NVE.cpp
@@ -87,7 +87,7 @@ struct Config
     const std::vector<std::string> typeNames = {"Ar"};  ///< atom type names for output files
 };
 
-void runSimulation(Config& config)
+void runLennardJones(Config& config)
 {
     // initialize simulation domain
     auto subdomain =
@@ -113,7 +113,7 @@ void runSimulation(Config& config)
     idx_t rebuildCounter = 0;
 
     // set up interaction potential and force calculation and application
-    action::LennardJones LJ(config.r_cut, config.sigma, config.epsilon, config.r_cap);
+    action::LennardJones lennardJones(config.r_cut, config.sigma, config.epsilon, config.r_cap);
 
     // set up thermostat for temperature control during equilibration
     action::LangevinThermostat langevinThermostat(config.gamma, config.temperature, config.dt);
@@ -136,7 +136,7 @@ void runSimulation(Config& config)
     // main simulation loop
     for (auto step = 0; step < config.nsteps; ++step)
     {
-        // integrate equations of motion - first half step (drift)
+        // integrate equations of motion before force calculation
         maxAtomDisplacement += action::VelocityVerlet::preForceIntegrate(atoms, config.dt);
 
         // reinsert atoms that left the domain according to periodic boundary conditions
@@ -171,16 +171,26 @@ void runSimulation(Config& config)
         Cabana::deep_copy(force, 0_r);
 
         // compute and apply forces
-        LJ.apply(atoms, verletList);
+        lennardJones.apply(atoms, verletList);
 
         // contribute forces calculated on ghost atoms back to real atoms
         ghostLayer.contributeBackGhostToReal(atoms);
+
+        // check if still during equilibration phase
+        if (step <= config.nstepsEq)
+        {
+            // apply Langevin thermostat for temperature control during equilibration
+            langevinThermostat.apply(atoms);
+        }
+
+        // integrate equations of motion after force calculation
+        action::VelocityVerlet::postForceIntegrate(atoms, config.dt);
 
         // handle output and statistics
         if (config.bOutput && (step % config.outputInterval == 0))
         {
             // calculate statistics
-            auto E0 = LJ.getEnergy() / real_c(atoms.numLocalAtoms);
+            auto E0 = lennardJones.getEnergy() / real_c(atoms.numLocalAtoms);
             auto Ek = analysis::getMeanKineticEnergy(atoms);
             auto systemMomentum = analysis::getSystemMomentum(atoms);
             auto T = (2_r / 3_r) * Ek;
@@ -206,16 +216,6 @@ void runSimulation(Config& config)
                   << E0 + Ek << " " << p << " " << msd << " " << atoms.numLocalAtoms << " "
                   << atoms.numGhostAtoms << " " << std::endl;
         }
-
-        // check if still during equilibration phase
-        if (step <= config.nstepsEq)
-        {
-            // apply Langevin thermostat for temperature control during equilibration
-            langevinThermostat.apply(atoms);
-        }
-
-        // integrate equations of motion - second half step (kick)
-        action::VelocityVerlet::postForceIntegrate(atoms, config.dt);
     }
 
     // close statistics file
@@ -233,8 +233,8 @@ void runSimulation(Config& config)
 
 int main(int argc, char* argv[])  // NOLINT
 {
-    // initialize Kokkos and MPI environment
-    initialize(argc, argv);
+    // initialize Kokkos environment
+    Kokkos::ScopeGuard scope_guard(argc, argv);
 
     // print Kokkos execution space
     std::cout << "execution space: " << typeid(Kokkos::DefaultExecutionSpace).name() << std::endl;
@@ -256,10 +256,7 @@ int main(int argc, char* argv[])  // NOLINT
     if (config.outputInterval < 0) config.bOutput = false;
 
     // set up, equilibrate in NVT and run production in NVE
-    runSimulation(config);
-
-    // finalize Kokkos and MPI environment
-    finalize();
+    runLennardJones(config);
 
     return EXIT_SUCCESS;
 }

--- a/examples/01_Argon_NVE/CMakeLists.txt
+++ b/examples/01_Argon_NVE/CMakeLists.txt
@@ -12,13 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(01_Argon_NVE)
-add_subdirectory(Argon)
-add_subdirectory(BinaryLennardJones)
-add_subdirectory(ComplexAtomics)
-add_subdirectory(DensityFluctuations)
-add_subdirectory(IdealGas)
-add_subdirectory(LennardJones)
-add_subdirectory(SPC)
-add_subdirectory(SpartianLJ)
-add_subdirectory(Vectorization)
+add_executable(01_Argon_NVE
+        01_Argon_NVE.cpp
+        )
+target_link_libraries(01_Argon_NVE
+        PRIVATE mrmd CLI11::CLI11
+        )
+add_test(NAME Example.01_Argon_NVE COMMAND ./01_Argon_NVE --nsteps 10)

--- a/examples/Argon/Argon.cpp
+++ b/examples/Argon/Argon.cpp
@@ -1,24 +1,23 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <format>
-
 #include <CLI/App.hpp>
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
 #include <Kokkos_Core.hpp>
 #include <algorithm>
+#include <format>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -43,6 +42,7 @@
 #include "io/RestoreTXT.hpp"
 #include "util/EnvironmentVariables.hpp"
 #include "util/PrintTable.hpp"
+#include "util/simulationSetup.hpp"
 
 using namespace mrmd;
 
@@ -72,58 +72,27 @@ struct Config
 
     idx_t estimatedMaxNeighbors = 60;
 
-    const std::string resName = "Argon"; 
+    const std::string resName = "Argon";
     const std::vector<std::string> typeNames = {"Ar"};
 };
-
-data::Atoms fillDomainWithAtomsSC(const data::Subdomain& subdomain,
-                                  const idx_t& numAtoms,
-                                  const real_t& maxVelocity)
-{
-    auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
-
-    data::Atoms atoms(numAtoms);
-
-    auto pos = atoms.getPos();
-    auto vel = atoms.getVel();
-    auto mass = atoms.getMass();
-    auto type = atoms.getType();
-    auto charge = atoms.getCharge();
-
-    auto policy = Kokkos::RangePolicy<>(0, numAtoms);
-    auto kernel = KOKKOS_LAMBDA(const idx_t idx)
-    {
-        auto randGen = RNG.get_state();
-        pos(idx, 0) = randGen.drand() * subdomain.diameter[0] + subdomain.minCorner[0];
-        pos(idx, 1) = randGen.drand() * subdomain.diameter[1] + subdomain.minCorner[1];
-        pos(idx, 2) = randGen.drand() * subdomain.diameter[2] + subdomain.minCorner[2];
-
-        vel(idx, 0) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 1) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 2) = (randGen.drand() - 0.5_r) * maxVelocity;
-        RNG.free_state(randGen);
-
-        mass(idx) = Config::mass;
-        type(idx) = 0;
-        charge(idx) = 0_r;
-    };
-    Kokkos::parallel_for("fillDomainWithAtomsSC", policy, kernel);
-
-    atoms.numLocalAtoms = numAtoms;
-    atoms.numGhostAtoms = 0;
-    return atoms;
-}
 
 void LJ(Config& config)
 {
     auto subdomain =
         data::Subdomain({0_r, 0_r, 0_r}, {config.Lx, config.Lx, config.Lx}, config.neighborCutoff);
     const auto volume = subdomain.diameter[0] * subdomain.diameter[1] * subdomain.diameter[2];
-    auto atoms = fillDomainWithAtomsSC(subdomain, config.numAtoms, 1_r);
+    auto atoms = util::fillRectangularDomainWithAtoms(subdomain, config.numAtoms, 1_r, config.mass);
     auto rho = real_c(atoms.numLocalAtoms) / volume;
     std::cout << "rho: " << rho << std::endl;
 
-    io::dumpGRO("atoms_initial.gro", atoms, subdomain, 0_r, "Argon", config.resName, config.typeNames, false);
+    io::dumpGRO("atoms_initial.gro",
+                atoms,
+                subdomain,
+                0_r,
+                "Argon",
+                config.resName,
+                config.typeNames,
+                false);
 
     communication::GhostLayer ghostLayer;
     action::LennardJones LJ(config.rc, config.sigma, config.epsilon, 0.7_r * config.sigma);

--- a/examples/Argon/MultiResArgon.cpp
+++ b/examples/Argon/MultiResArgon.cpp
@@ -1,24 +1,23 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <format>
-
 #include <CLI/App.hpp>
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
 #include <Kokkos_Core.hpp>
 #include <algorithm>
+#include <format>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -46,6 +45,7 @@
 #include "io/RestoreTXT.hpp"
 #include "util/EnvironmentVariables.hpp"
 #include "util/PrintTable.hpp"
+#include "util/simulationSetup.hpp"
 #include "weighting_function/Slab.hpp"
 
 using namespace mrmd;
@@ -76,62 +76,28 @@ struct Config
 
     idx_t estimatedMaxNeighbors = 60;
 
-    const std::string resName = "Argon"; 
+    const std::string resName = "Argon";
     const std::vector<std::string> typeNames = {"Ar"};
-
 };
-
-data::Atoms fillDomainWithAtomsSC(const data::Subdomain& subdomain,
-                                  const idx_t& numAtoms,
-                                  const real_t& maxVelocity)
-{
-    auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
-
-    data::Atoms atoms(numAtoms);
-
-    auto pos = atoms.getPos();
-    auto vel = atoms.getVel();
-    auto mass = atoms.getMass();
-    auto type = atoms.getType();
-    auto charge = atoms.getCharge();
-    auto relativeMass = atoms.getRelativeMass();
-
-    auto policy = Kokkos::RangePolicy<>(0, numAtoms);
-    auto kernel = KOKKOS_LAMBDA(const idx_t idx)
-    {
-        auto randGen = RNG.get_state();
-        pos(idx, 0) = randGen.drand() * subdomain.diameter[0] + subdomain.minCorner[0];
-        pos(idx, 1) = randGen.drand() * subdomain.diameter[1] + subdomain.minCorner[1];
-        pos(idx, 2) = randGen.drand() * subdomain.diameter[2] + subdomain.minCorner[2];
-
-        vel(idx, 0) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 1) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 2) = (randGen.drand() - 0.5_r) * maxVelocity;
-        RNG.free_state(randGen);
-
-        mass(idx) = Config::mass;
-        type(idx) = 0;
-        charge(idx) = 0_r;
-        relativeMass(idx) = 1_r;
-    };
-    Kokkos::parallel_for("fillDomainWithAtomsSC", policy, kernel);
-
-    atoms.numLocalAtoms = numAtoms;
-    atoms.numGhostAtoms = 0;
-    return atoms;
-}
 
 void LJ(Config& config)
 {
     auto subdomain =
         data::Subdomain({0_r, 0_r, 0_r}, {config.Lx, config.Lx, config.Lx}, config.neighborCutoff);
     const auto volume = subdomain.diameter[0] * subdomain.diameter[1] * subdomain.diameter[2];
-    auto atoms = fillDomainWithAtomsSC(subdomain, config.numAtoms, 1_r);
+    auto atoms = util::fillRectangularDomainWithAtoms(subdomain, config.numAtoms, 1_r, config.mass);
     auto molecules = data::createMoleculeForEachAtom(atoms);
     auto rho = real_c(atoms.numLocalAtoms) / volume;
     std::cout << "rho: " << rho << std::endl;
 
-    io::dumpGRO("atoms_initial.gro", atoms, subdomain, 0_r, "Argon", config.resName, config.typeNames, false);
+    io::dumpGRO("atoms_initial.gro",
+                atoms,
+                subdomain,
+                0_r,
+                "Argon",
+                config.resName,
+                config.typeNames,
+                false);
 
     communication::MultiResGhostLayer ghostLayer;
     weighting_function::Slab weightingFunction({-100_r, -100_r, -100_r}, 1_r, 1_r, 1);
@@ -230,7 +196,7 @@ void LJ(Config& config)
                         subdomain,
                         step * config.dt,
                         "Argon",
-                        config.resName, 
+                        config.resName,
                         config.typeNames,
                         false);
 

--- a/examples/BinaryLennardJones/BinaryLennardJones.cpp
+++ b/examples/BinaryLennardJones/BinaryLennardJones.cpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])  // NOLINT
     std::cout << "==================" << std::endl;
 
     LJ(cfg);
-    
+
     MPI_Finalize();
 
     return EXIT_SUCCESS;

--- a/examples/BinaryLennardJones/NPT.cpp
+++ b/examples/BinaryLennardJones/NPT.cpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,9 +14,8 @@
 
 #include "NPT.hpp"
 
-#include <format>
-
 #include <algorithm>
+#include <format>
 
 #include "action/BerendsenBarostat.hpp"
 #include "action/BerendsenThermostat.hpp"

--- a/examples/BinaryLennardJones/NPT.hpp
+++ b/examples/BinaryLennardJones/NPT.hpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/examples/BinaryLennardJones/NVT.cpp
+++ b/examples/BinaryLennardJones/NVT.cpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,9 +14,8 @@
 
 #include "NVT.hpp"
 
-#include <format>
-
 #include <algorithm>
+#include <format>
 
 #include "action/BerendsenThermostat.hpp"
 #include "action/LennardJones.hpp"

--- a/examples/BinaryLennardJones/NVT.hpp
+++ b/examples/BinaryLennardJones/NVT.hpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/examples/BinaryLennardJones/SPARTIAN.cpp
+++ b/examples/BinaryLennardJones/SPARTIAN.cpp
@@ -14,9 +14,8 @@
 
 #include "SPARTIAN.hpp"
 
-#include <format>
-
 #include <algorithm>
+#include <format>
 #include <fstream>
 
 #include "action/ContributeMoleculeForceToAtoms.hpp"

--- a/examples/BinaryLennardJones/SPARTIAN.hpp
+++ b/examples/BinaryLennardJones/SPARTIAN.hpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/examples/BinaryLennardJones/initialization.cpp
+++ b/examples/BinaryLennardJones/initialization.cpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,53 +19,10 @@
 
 #include "data/MPIInfo.hpp"
 #include "io/RestoreH5MDParallel.hpp"
+#include "util/simulationSetup.hpp"
 
 namespace mrmd
 {
-data::Atoms fillDomainWithAtomsSC(const data::Subdomain& subdomain,
-                                  const idx_t& numAtoms,
-                                  const real_t& fracTypeA,
-                                  const real_t& maxVelocity)
-{
-    assert(fracTypeA < 1_r);
-    assert(fracTypeA > 0_r);
-    auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
-
-    data::Atoms atoms(numAtoms);
-
-    auto pos = atoms.getPos();
-    auto vel = atoms.getVel();
-    auto mass = atoms.getMass();
-    auto relativeMass = atoms.getRelativeMass();
-    auto type = atoms.getType();
-
-    auto numAtomsA = int_c(real_c(numAtoms) * fracTypeA);
-
-    auto policy = Kokkos::RangePolicy<>(0, numAtoms);
-    auto kernel = KOKKOS_LAMBDA(const idx_t idx)
-    {
-        auto randGen = RNG.get_state();
-        pos(idx, 0) = randGen.drand() * subdomain.diameter[0] + subdomain.minCorner[0];
-        pos(idx, 1) = randGen.drand() * subdomain.diameter[1] + subdomain.minCorner[1];
-        pos(idx, 2) = randGen.drand() * subdomain.diameter[2] + subdomain.minCorner[2];
-
-        vel(idx, 0) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 1) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 2) = (randGen.drand() - 0.5_r) * maxVelocity;
-        RNG.free_state(randGen);
-
-        mass(idx) = 1_r;
-        relativeMass(idx) = 1_r;
-
-        type(idx) = idx < numAtomsA ? 0 : 1;
-    };
-    Kokkos::parallel_for("fillDomainWithAtomsSC", policy, kernel);
-
-    atoms.numLocalAtoms = numAtoms;
-    atoms.numGhostAtoms = 0;
-    return atoms;
-}
-
 void init(const YAML::Node& config, data::Atoms& atoms, data::Subdomain& subdomain)
 {
     if (config["restore_file"].IsDefined())
@@ -88,10 +45,12 @@ void init(const YAML::Node& config, data::Atoms& atoms, data::Subdomain& subdoma
                                  config["box"][2].as<real_t>()},
                                 config["ghost_layer_thickness"].as<real_t>());
 
-    atoms = fillDomainWithAtomsSC(subdomain,
-                                  config["num_atoms"].as<int64_t>(),
-                                  config["fraction_type_A"].as<real_t>(),
-                                  config["max_velocity"].as<real_t>());
+    atoms = util::fillRectDomainWithTwoAtomisticSpecies(subdomain,
+                                                        config["num_atoms"].as<int64_t>(),
+                                                        config["fraction_type_A"].as<real_t>(),
+                                                        config["max_velocity"].as<real_t>(),
+                                                        1_r,
+                                                        1_r);
 }
 
 data::Molecules initMolecules(const idx_t& numAtoms)

--- a/examples/BinaryLennardJones/initialization.hpp
+++ b/examples/BinaryLennardJones/initialization.hpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(01_Argon_NVE)
 add_subdirectory(00_IdealGas_NVE)
+add_subdirectory(01_Argon_NVE)
 
 add_subdirectory(Argon)
 add_subdirectory(BinaryLennardJones)

--- a/examples/ComplexAtomics/ComplexAtomics.cpp
+++ b/examples/ComplexAtomics/ComplexAtomics.cpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/examples/DensityFluctuations/DensityFluctuations.cpp
+++ b/examples/DensityFluctuations/DensityFluctuations.cpp
@@ -1,23 +1,22 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <format>
-
 #include <CLI/App.hpp>
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
 #include <Kokkos_Core.hpp>
+#include <format>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -45,6 +44,7 @@
 #include "io/RestoreTXT.hpp"
 #include "util/EnvironmentVariables.hpp"
 #include "util/PrintTable.hpp"
+#include "util/simulationSetup.hpp"
 
 using namespace mrmd;
 
@@ -86,47 +86,9 @@ struct Config
     // thermodynamic force parameters
     real_t thermodynamicForceModulation = 2.0_r;
 
-    const std::string resName = "Argon"; 
+    const std::string resName = "Argon";
     const std::vector<std::string> typeNames = {"Ar"};
 };
-
-data::Atoms fillDomainWithAtomsSC(const data::Subdomain& subdomain,
-                                  const idx_t& numAtoms,
-                                  const real_t& maxVelocity)
-{
-    auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
-
-    data::Atoms atoms(numAtoms);
-
-    auto pos = atoms.getPos();
-    auto vel = atoms.getVel();
-    auto mass = atoms.getMass();
-    auto type = atoms.getType();
-    auto charge = atoms.getCharge();
-
-    auto policy = Kokkos::RangePolicy<>(0, numAtoms);
-    auto kernel = KOKKOS_LAMBDA(const idx_t idx)
-    {
-        auto randGen = RNG.get_state();
-        pos(idx, 0) = randGen.drand() * subdomain.diameter[0] + subdomain.minCorner[0];
-        pos(idx, 1) = randGen.drand() * subdomain.diameter[1] + subdomain.minCorner[1];
-        pos(idx, 2) = randGen.drand() * subdomain.diameter[2] + subdomain.minCorner[2];
-
-        vel(idx, 0) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 1) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 2) = (randGen.drand() - 0.5_r) * maxVelocity;
-        RNG.free_state(randGen);
-
-        mass(idx) = Config::mass;
-        type(idx) = 0;
-        charge(idx) = 0_r;
-    };
-    Kokkos::parallel_for("fillDomainWithAtomsSC", policy, kernel);
-
-    atoms.numLocalAtoms = numAtoms;
-    atoms.numGhostAtoms = 0;
-    return atoms;
-}
 
 void LJ(Config& config)
 {
@@ -134,11 +96,18 @@ void LJ(Config& config)
                                      {config.Lx, config.Ly, config.Lz},
                                      config.neighborCutoff);
     const auto volume = subdomain.diameter[0] * subdomain.diameter[1] * subdomain.diameter[2];
-    auto atoms = fillDomainWithAtomsSC(subdomain, config.numAtoms, 1_r);
+    auto atoms = util::fillRectangularDomainWithAtoms(subdomain, config.numAtoms, 1_r, config.mass);
     auto rho = real_c(atoms.numLocalAtoms) / volume;
     std::cout << "rho: " << rho << std::endl;
 
-    io::dumpGRO("atoms_initial.gro", atoms, subdomain, 0_r, "Argon", config.resName, config.typeNames, false);
+    io::dumpGRO("atoms_initial.gro",
+                atoms,
+                subdomain,
+                0_r,
+                "Argon",
+                config.resName,
+                config.typeNames,
+                false);
 
     communication::GhostLayer ghostLayer;
     action::LennardJones LJ(config.rc, config.sigma, config.epsilon, 0.7_r * config.sigma);

--- a/examples/LennardJones/LennardJones.cpp
+++ b/examples/LennardJones/LennardJones.cpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,6 +36,7 @@
 #include "io/RestoreTXT.hpp"
 #include "util/EnvironmentVariables.hpp"
 #include "util/PrintTable.hpp"
+#include "util/simulationSetup.hpp"
 
 using namespace mrmd;
 
@@ -63,40 +64,6 @@ struct Config
     idx_t estimatedMaxNeighbors = 60;
 };
 
-data::Atoms fillDomainWithAtomsSC(const data::Subdomain& subdomain,
-                                  const idx_t& numAtoms,
-                                  const real_t& maxVelocity)
-{
-    auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
-
-    data::Atoms atoms(numAtoms);
-
-    auto pos = atoms.getPos();
-    auto vel = atoms.getVel();
-    auto mass = atoms.getMass();
-
-    auto policy = Kokkos::RangePolicy<>(0, numAtoms);
-    auto kernel = KOKKOS_LAMBDA(const idx_t idx)
-    {
-        auto randGen = RNG.get_state();
-        pos(idx, 0) = randGen.drand() * subdomain.diameter[0] + subdomain.minCorner[0];
-        pos(idx, 1) = randGen.drand() * subdomain.diameter[1] + subdomain.minCorner[1];
-        pos(idx, 2) = randGen.drand() * subdomain.diameter[2] + subdomain.minCorner[2];
-
-        vel(idx, 0) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 1) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 2) = (randGen.drand() - 0.5_r) * maxVelocity;
-        RNG.free_state(randGen);
-
-        mass(idx) = 1_r;
-    };
-    Kokkos::parallel_for("fillDomainWithAtomsSC", policy, kernel);
-
-    atoms.numLocalAtoms = numAtoms;
-    atoms.numGhostAtoms = 0;
-    return atoms;
-}
-
 void LJ(Config& config)
 {
     auto subdomain =
@@ -110,7 +77,8 @@ void LJ(Config& config)
     }
     else
     {
-        atoms = fillDomainWithAtomsSC(subdomain, idx_c(config.rho * volume), 1_r);
+        atoms =
+            util::fillRectangularDomainWithAtoms(subdomain, idx_c(config.rho * volume), 1_r, 1_r);
     }
 
     auto rho = real_c(atoms.numLocalAtoms) / volume;

--- a/examples/SPC/SPC.cpp
+++ b/examples/SPC/SPC.cpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,12 +14,11 @@
 
 #include "action/SPC.hpp"
 
-#include <format>
-
 #include <CLI/App.hpp>
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
 #include <Kokkos_Core.hpp>
+#include <format>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -363,25 +362,25 @@ void SPC(Config& config)
         if (config.bOutput && (step > config.nsteps - 5000) && (step % 100 == 0))
         {
             io::dumpCSV(std::format("spc_{:0>6}.csv", step), atoms, false);
-            //io::dumpGRO(std::format("spc_{:0>6}.gro", step),
-            //            atoms,
-            //            subdomain,
-            //            step * config.dt,
-            //            "SPC water",
-            //            false,
-            //            true);
+            // io::dumpGRO(std::format("spc_{:0>6}.gro", step),
+            //             atoms,
+            //             subdomain,
+            //             step * config.dt,
+            //             "SPC water",
+            //             false,
+            //             true);
         }
 
         if (config.bOutput && (step > config.nsteps - 500) && (step % 10 == 0))
         {
             io::dumpCSV(std::format("spc_{:0>6}.csv", step), atoms, false);
-            //io::dumpGRO(std::format("spc_{:0>6}.gro", step),
-            //            atoms,
-            //            subdomain,
-            //            step * config.dt,
-            //            "SPC water",
-            //            false,
-            //            true);
+            // io::dumpGRO(std::format("spc_{:0>6}.gro", step),
+            //             atoms,
+            //             subdomain,
+            //             step * config.dt,
+            //             "SPC water",
+            //             false,
+            //             true);
         }
 
         if (step == 2000) config.thermostatInterval = 2000;

--- a/examples/SpartianLJ/SpartianLJ.cpp
+++ b/examples/SpartianLJ/SpartianLJ.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <format>
-
 #include <CLI/App.hpp>
 #include <CLI/Config.hpp>
 #include <CLI/Formatter.hpp>
 #include <Kokkos_Core.hpp>
+#include <format>
 #include <fstream>
 #include <iomanip>
 #include <iostream>

--- a/examples/Vectorization/vec.cpp
+++ b/examples/Vectorization/vec.cpp
@@ -1,11 +1,11 @@
 // Copyright 2024 Sebastian Eibl
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/mrmd/util/CMakeLists.txt
+++ b/mrmd/util/CMakeLists.txt
@@ -29,3 +29,6 @@ mrmd_add_test(NAME test.util.interpolation
 
 mrmd_add_test(NAME test.util.Random
         FILES Random.test.cpp)
+
+mrmd_add_test(NAME test.util.simulationSetup
+        FILES simulationSetup.test.cpp)

--- a/mrmd/util/simulationSetup.cpp
+++ b/mrmd/util/simulationSetup.cpp
@@ -19,9 +19,9 @@ namespace mrmd
 namespace util
 {
 data::Atoms fillDomainWithAtoms(const data::Subdomain& subdomain,
-                                  const idx_t& numAtoms,
-                                  const real_t& maxVelocity,
-                                  const real_t& inputMass)
+                                const idx_t& numAtoms,
+                                const real_t& maxVelocity,
+                                const real_t& inputMass)
 {
     auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
 

--- a/mrmd/util/simulationSetup.cpp
+++ b/mrmd/util/simulationSetup.cpp
@@ -1,0 +1,61 @@
+// Copyright 2024 Sebastian Eibl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/simulationSetup.hpp"
+
+namespace mrmd
+{
+namespace util
+{
+data::Atoms fillDomainWithAtoms(const data::Subdomain& subdomain,
+                                  const idx_t& numAtoms,
+                                  const real_t& maxVelocity,
+                                  const real_t& inputMass)
+{
+    auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
+
+    data::Atoms atoms(numAtoms);
+
+    auto pos = atoms.getPos();
+    auto vel = atoms.getVel();
+    auto mass = atoms.getMass();
+    auto type = atoms.getType();
+    auto charge = atoms.getCharge();
+
+    auto policy = Kokkos::RangePolicy<>(0, numAtoms);
+    auto kernel = KOKKOS_LAMBDA(const idx_t idx)
+    {
+        auto randGen = RNG.get_state();
+        pos(idx, 0) = randGen.drand() * subdomain.diameter[0] + subdomain.minCorner[0];
+        pos(idx, 1) = randGen.drand() * subdomain.diameter[1] + subdomain.minCorner[1];
+        pos(idx, 2) = randGen.drand() * subdomain.diameter[2] + subdomain.minCorner[2];
+
+        vel(idx, 0) = (randGen.drand() - 0.5_r) * maxVelocity;
+        vel(idx, 1) = (randGen.drand() - 0.5_r) * maxVelocity;
+        vel(idx, 2) = (randGen.drand() - 0.5_r) * maxVelocity;
+        RNG.free_state(randGen);
+
+        mass(idx) = inputMass;
+        type(idx) = 0;
+        charge(idx) = 0_r;
+    };
+    Kokkos::parallel_for("fillDomainWithAtoms", policy, kernel);
+
+    atoms.numLocalAtoms = numAtoms;
+    atoms.numGhostAtoms = 0;
+    return atoms;
+}
+
+}  // namespace util
+}  // namespace mrmd

--- a/mrmd/util/simulationSetup.cpp
+++ b/mrmd/util/simulationSetup.cpp
@@ -30,6 +30,7 @@ data::Atoms fillRectangularDomainWithAtoms(const data::Subdomain& subdomain,
     auto pos = atoms.getPos();
     auto vel = atoms.getVel();
     auto mass = atoms.getMass();
+    auto relativeMass = atoms.getRelativeMass();
     auto type = atoms.getType();
     auto charge = atoms.getCharge();
 
@@ -47,6 +48,7 @@ data::Atoms fillRectangularDomainWithAtoms(const data::Subdomain& subdomain,
         RNG.free_state(randGen);
 
         mass(idx) = inputMass;
+        relativeMass(idx) = 1_r;
         type(idx) = 0;
         charge(idx) = 0_r;
     };

--- a/mrmd/util/simulationSetup.cpp
+++ b/mrmd/util/simulationSetup.cpp
@@ -57,5 +57,51 @@ data::Atoms fillRectangularDomainWithAtoms(const data::Subdomain& subdomain,
     return atoms;
 }
 
+data::Atoms fillRectDomainWithTwoAtomisticSpecies(const data::Subdomain& subdomain,
+                                                  const idx_t& numAtoms,
+                                                  const real_t& fracTypeA,
+                                                  const real_t& maxVelocity,
+                                                  const real_t& massA,
+                                                  const real_t& massB)
+{
+    assert(fracTypeA < 1_r);
+    assert(fracTypeA > 0_r);
+    auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
+
+    data::Atoms atoms(numAtoms);
+
+    auto pos = atoms.getPos();
+    auto vel = atoms.getVel();
+    auto mass = atoms.getMass();
+    auto relativeMass = atoms.getRelativeMass();
+    auto type = atoms.getType();
+
+    auto numAtomsA = int_c(real_c(numAtoms) * fracTypeA);
+
+    auto policy = Kokkos::RangePolicy<>(0, numAtoms);
+    auto kernel = KOKKOS_LAMBDA(const idx_t idx)
+    {
+        auto randGen = RNG.get_state();
+        pos(idx, 0) = randGen.drand() * subdomain.diameter[0] + subdomain.minCorner[0];
+        pos(idx, 1) = randGen.drand() * subdomain.diameter[1] + subdomain.minCorner[1];
+        pos(idx, 2) = randGen.drand() * subdomain.diameter[2] + subdomain.minCorner[2];
+
+        vel(idx, 0) = (randGen.drand() - 0.5_r) * maxVelocity;
+        vel(idx, 1) = (randGen.drand() - 0.5_r) * maxVelocity;
+        vel(idx, 2) = (randGen.drand() - 0.5_r) * maxVelocity;
+        RNG.free_state(randGen);
+
+        mass(idx) = idx < numAtomsA ? massA : massB;
+        relativeMass(idx) = idx < numAtomsA ? massA : massB;
+
+        type(idx) = idx < numAtomsA ? 0 : 1;
+    };
+    Kokkos::parallel_for("fillDomainWithAtomsSC", policy, kernel);
+
+    atoms.numLocalAtoms = numAtoms;
+    atoms.numGhostAtoms = 0;
+    return atoms;
+}
+
 }  // namespace util
 }  // namespace mrmd

--- a/mrmd/util/simulationSetup.cpp
+++ b/mrmd/util/simulationSetup.cpp
@@ -18,10 +18,10 @@ namespace mrmd
 {
 namespace util
 {
-data::Atoms fillDomainWithAtoms(const data::Subdomain& subdomain,
-                                const idx_t& numAtoms,
-                                const real_t& maxVelocity,
-                                const real_t& inputMass)
+data::Atoms fillRectangularDomainWithAtoms(const data::Subdomain& subdomain,
+                                           const idx_t& numAtoms,
+                                           const real_t& maxVelocity,
+                                           const real_t& inputMass)
 {
     auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
 

--- a/mrmd/util/simulationSetup.cpp
+++ b/mrmd/util/simulationSetup.cpp
@@ -50,7 +50,7 @@ data::Atoms fillRectangularDomainWithAtoms(const data::Subdomain& subdomain,
         type(idx) = 0;
         charge(idx) = 0_r;
     };
-    Kokkos::parallel_for("fillDomainWithAtoms", policy, kernel);
+    Kokkos::parallel_for("fillRectangularDomainWithAtoms", policy, kernel);
 
     atoms.numLocalAtoms = numAtoms;
     atoms.numGhostAtoms = 0;
@@ -96,7 +96,7 @@ data::Atoms fillRectDomainWithTwoAtomisticSpecies(const data::Subdomain& subdoma
 
         type(idx) = idx < numAtomsA ? 0 : 1;
     };
-    Kokkos::parallel_for("fillDomainWithAtomsSC", policy, kernel);
+    Kokkos::parallel_for("fillRectDomainWithTwoAtomisticSpecies", policy, kernel);
 
     atoms.numLocalAtoms = numAtoms;
     atoms.numGhostAtoms = 0;

--- a/mrmd/util/simulationSetup.hpp
+++ b/mrmd/util/simulationSetup.hpp
@@ -23,9 +23,9 @@ namespace mrmd
 namespace util
 {
 data::Atoms fillDomainWithAtoms(const data::Subdomain& subdomain,
-                                  const idx_t& numAtoms,
-                                  const real_t& maxVelocity,
-                                  const real_t& inputMass);
+                                const idx_t& numAtoms,
+                                const real_t& maxVelocity,
+                                const real_t& inputMass);
 
 }  // namespace util
 }  // namespace mrmd

--- a/mrmd/util/simulationSetup.hpp
+++ b/mrmd/util/simulationSetup.hpp
@@ -1,0 +1,31 @@
+// Copyright 2024 Sebastian Eibl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "data/Atoms.hpp"
+#include "data/Subdomain.hpp"
+#include "datatypes.hpp"
+
+namespace mrmd
+{
+namespace util
+{
+data::Atoms fillDomainWithAtoms(const data::Subdomain& subdomain,
+                                  const idx_t& numAtoms,
+                                  const real_t& maxVelocity,
+                                  const real_t& inputMass);
+
+}  // namespace util
+}  // namespace mrmd

--- a/mrmd/util/simulationSetup.hpp
+++ b/mrmd/util/simulationSetup.hpp
@@ -27,5 +27,12 @@ data::Atoms fillRectangularDomainWithAtoms(const data::Subdomain& subdomain,
                                            const real_t& maxVelocity,
                                            const real_t& inputMass);
 
+data::Atoms fillRectDomainWithTwoAtomisticSpecies(const data::Subdomain& subdomain,
+                                                  const idx_t& numAtoms,
+                                                  const real_t& fracTypeA,
+                                                  const real_t& maxVelocity,
+                                                  const real_t& massA,
+                                                  const real_t& massB);
+
 }  // namespace util
 }  // namespace mrmd

--- a/mrmd/util/simulationSetup.hpp
+++ b/mrmd/util/simulationSetup.hpp
@@ -22,10 +22,10 @@ namespace mrmd
 {
 namespace util
 {
-data::Atoms fillDomainWithAtoms(const data::Subdomain& subdomain,
-                                const idx_t& numAtoms,
-                                const real_t& maxVelocity,
-                                const real_t& inputMass);
+data::Atoms fillRectangularDomainWithAtoms(const data::Subdomain& subdomain,
+                                           const idx_t& numAtoms,
+                                           const real_t& maxVelocity,
+                                           const real_t& inputMass);
 
 }  // namespace util
 }  // namespace mrmd

--- a/mrmd/util/simulationSetup.test.cpp
+++ b/mrmd/util/simulationSetup.test.cpp
@@ -1,0 +1,60 @@
+// Copyright 2024 Sebastian Eibl
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/simulationSetup.hpp"
+
+#include <gtest/gtest.h>
+
+namespace mrmd
+{
+namespace util
+{
+TEST(simulationSetup, testFillDomain)
+{
+    data::Subdomain subdomain({1, 2, 3}, {3, 6, 9}, 0.5_r);
+    data::Atoms atoms = fillDomainWithAtoms(subdomain, 100, 1_r, 1_r);
+
+    EXPECT_EQ(atoms.size(), 100);
+
+    auto hAoSoA = Cabana::create_mirror_view_and_copy(Kokkos::HostSpace(), atoms.getAoSoA());
+    auto pos = Cabana::slice<data::Atoms::POS>(hAoSoA);
+    auto vel = Cabana::slice<data::Atoms::VEL>(hAoSoA);
+    auto mass = Cabana::slice<data::Atoms::MASS>(hAoSoA);
+    auto type = Cabana::slice<data::Atoms::TYPE>(hAoSoA);
+    auto charge = Cabana::slice<data::Atoms::CHARGE>(hAoSoA);
+
+    for (idx_t idx = 0; idx < atoms.size(); ++idx)
+    {
+        EXPECT_GE(pos(idx, 0), subdomain.minCorner[0]);
+        EXPECT_LE(pos(idx, 0), subdomain.maxCorner[0]);
+        EXPECT_GE(pos(idx, 1), subdomain.minCorner[1]);
+        EXPECT_LE(pos(idx, 1), subdomain.maxCorner[1]);
+        EXPECT_GE(pos(idx, 2), subdomain.minCorner[2]);
+        EXPECT_LE(pos(idx, 2), subdomain.maxCorner[2]);
+
+        EXPECT_GE(vel(idx, 0), -0.5_r);
+        EXPECT_LE(vel(idx, 0), +0.5_r);
+        EXPECT_GE(vel(idx, 1), -0.5_r);
+        EXPECT_LE(vel(idx, 1), +0.5_r);
+        EXPECT_GE(vel(idx, 2), -0.5_r);
+        EXPECT_LE(vel(idx, 2), +0.5_r);
+
+        EXPECT_FLOAT_EQ(mass(idx), 1_r);
+        EXPECT_EQ(type(idx), 0);
+        EXPECT_FLOAT_EQ(charge(idx), 0_r);
+    }
+}
+
+}  // namespace util
+}  // namespace mrmd

--- a/mrmd/util/simulationSetup.test.cpp
+++ b/mrmd/util/simulationSetup.test.cpp
@@ -23,7 +23,7 @@ namespace util
 TEST(simulationSetup, testFillDomain)
 {
     data::Subdomain subdomain({1, 2, 3}, {3, 6, 9}, 0.5_r);
-    data::Atoms atoms = fillDomainWithAtoms(subdomain, 100, 1_r, 1_r);
+    data::Atoms atoms = fillRectangularDomainWithAtoms(subdomain, 100, 1_r, 1_r);
 
     EXPECT_EQ(atoms.size(), 100);
 

--- a/tests/LangevinThermostat/LangevinThermostat.cpp
+++ b/tests/LangevinThermostat/LangevinThermostat.cpp
@@ -28,6 +28,7 @@
 #include "data/Subdomain.hpp"
 #include "datatypes.hpp"
 #include "util/IsInSymmetricSlab.hpp"
+#include "util/simulationSetup.hpp"
 
 using namespace mrmd;
 
@@ -47,45 +48,11 @@ struct Config
     real_t initialMaxVelocity = 10_r;
 };
 
-data::Atoms fillDomainWithAtomsSC(const data::Subdomain& subdomain,
-                                  const idx_t& numAtoms,
-                                  const real_t& maxVelocity)
-{
-    auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
-
-    data::Atoms atoms(numAtoms);
-
-    auto pos = atoms.getPos();
-    auto vel = atoms.getVel();
-    auto mass = atoms.getMass();
-
-    auto policy = Kokkos::RangePolicy<>(0, numAtoms);
-    auto kernel = KOKKOS_LAMBDA(const idx_t idx)
-    {
-        auto randGen = RNG.get_state();
-        pos(idx, 0) = randGen.drand() * subdomain.diameter[0] + subdomain.minCorner[0];
-        pos(idx, 1) = randGen.drand() * subdomain.diameter[1] + subdomain.minCorner[1];
-        pos(idx, 2) = randGen.drand() * subdomain.diameter[2] + subdomain.minCorner[2];
-
-        vel(idx, 0) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 1) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 2) = (randGen.drand() - 0.5_r) * maxVelocity;
-        RNG.free_state(randGen);
-
-        mass(idx) = 1_r;
-    };
-    Kokkos::parallel_for("fillDomainWithAtomsSC", policy, kernel);
-
-    atoms.numLocalAtoms = numAtoms;
-    atoms.numGhostAtoms = 0;
-    return atoms;
-}
-
 TEST(Integration, LangevinThermostat)
 {
     Config config;
     auto subdomain = data::Subdomain({0_r, 0_r, 0_r}, {config.Lx, config.Lx, config.Lx}, 1_r);
-    auto atoms = fillDomainWithAtomsSC(subdomain, config.numAtoms, config.initialMaxVelocity);
+    auto atoms = util::fillRectangularDomainWithAtoms(subdomain, config.numAtoms, config.initialMaxVelocity, 1_r);
 
     action::LangevinThermostat langevinThermostat(config.gamma, config.temperature, config.dt);
     for (auto step = 0; step < config.nsteps; ++step)
@@ -115,7 +82,7 @@ TEST(Integration, LocalLangevinThermostat)
 {
     Config config;
     auto subdomain = data::Subdomain({0_r, 0_r, 0_r}, {config.Lx, config.Lx, config.Lx}, 1_r);
-    auto atoms = fillDomainWithAtomsSC(subdomain, config.numAtoms, config.initialMaxVelocity);
+    auto atoms = util::fillRectangularDomainWithAtoms(subdomain, config.numAtoms, config.initialMaxVelocity, 1_r);
 
     real_t boxCenterX = 0.5_r * (subdomain.maxCorner[0] + subdomain.minCorner[0]);
     real_t boxCenterY = 0.5_r * (subdomain.maxCorner[1] + subdomain.minCorner[1]);
@@ -152,7 +119,7 @@ TEST(Integration, VelocityVerletLangevinThermostat)
 {
     Config config;
     auto subdomain = data::Subdomain({0_r, 0_r, 0_r}, {config.Lx, config.Lx, config.Lx}, 1_r);
-    auto atoms = fillDomainWithAtomsSC(subdomain, config.numAtoms, config.initialMaxVelocity);
+    auto atoms = util::fillRectangularDomainWithAtoms(subdomain, config.numAtoms, config.initialMaxVelocity, 1_r);
 
     action::VelocityVerletLangevinThermostat vv(1e5_r, config.temperature);
     for (auto step = 0; step < config.nsteps; ++step)

--- a/tests/NPT/NPT.cpp
+++ b/tests/NPT/NPT.cpp
@@ -37,6 +37,7 @@
 #include "util/EnvironmentVariables.hpp"
 #include "util/ExponentialMovingAverage.hpp"
 #include "util/PrintTable.hpp"
+#include "util/simulationSetup.hpp"
 
 using namespace mrmd;
 
@@ -64,40 +65,6 @@ struct Config
     static constexpr real_t weightingFactor = 0.02_r;
 };
 
-data::Atoms fillDomainWithAtomsSC(const data::Subdomain &subdomain,
-                                  const idx_t &numAtoms,
-                                  const real_t &maxVelocity)
-{
-    auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
-
-    data::Atoms atoms(numAtoms);
-
-    auto pos = atoms.getPos();
-    auto vel = atoms.getVel();
-    auto mass = atoms.getMass();
-
-    auto policy = Kokkos::RangePolicy<>(0, numAtoms);
-    auto kernel = KOKKOS_LAMBDA(const idx_t idx)
-    {
-        auto randGen = RNG.get_state();
-        pos(idx, 0) = randGen.drand() * subdomain.diameter[0] + subdomain.minCorner[0];
-        pos(idx, 1) = randGen.drand() * subdomain.diameter[1] + subdomain.minCorner[1];
-        pos(idx, 2) = randGen.drand() * subdomain.diameter[2] + subdomain.minCorner[2];
-
-        vel(idx, 0) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 1) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 2) = (randGen.drand() - 0.5_r) * maxVelocity;
-        RNG.free_state(randGen);
-
-        mass(idx) = 1_r;
-    };
-    Kokkos::parallel_for("fillDomainWithAtomsSC", policy, kernel);
-
-    atoms.numLocalAtoms = numAtoms;
-    atoms.numGhostAtoms = 0;
-    return atoms;
-}
-
 struct Input
 {
     real_t targetTemperature;
@@ -119,7 +86,7 @@ protected:
 
     data::Subdomain subdomain = {{0_r, 0_r, 0_r}, {Config::Lx, Config::Lx, Config::Lx}, Config::neighborCutoff};
     real_t volume = {subdomain.diameter[0] * subdomain.diameter[1] * subdomain.diameter[2]};
-    data::Atoms atoms = {fillDomainWithAtomsSC(subdomain, idx_c(Config::rho * volume), 1_r)};
+    data::Atoms atoms = {util::fillRectangularDomainWithAtoms(subdomain, idx_c(Config::rho * volume), 1_r, 1_r)};
     real_t rho = {real_c(atoms.numLocalAtoms) / volume};
     communication::GhostLayer ghostLayer;
     action::LennardJones LJ = {Config::rc, Config::sigma, Config::epsilon, 0.7_r * Config::sigma};

--- a/tests/NVT/NVT.cpp
+++ b/tests/NVT/NVT.cpp
@@ -36,6 +36,7 @@
 #include "util/EnvironmentVariables.hpp"
 #include "util/ExponentialMovingAverage.hpp"
 #include "util/PrintTable.hpp"
+#include "util/simulationSetup.hpp"
 
 using namespace mrmd;
 
@@ -61,40 +62,6 @@ struct Config
     static constexpr idx_t estimatedMaxNeighbors = 60;
 };
 
-data::Atoms fillDomainWithAtomsSC(const data::Subdomain& subdomain,
-                                  const idx_t& numAtoms,
-                                  const real_t& maxVelocity)
-{
-    auto RNG = Kokkos::Random_XorShift1024_Pool<>(1234);
-
-    data::Atoms atoms(numAtoms);
-
-    auto pos = atoms.getPos();
-    auto vel = atoms.getVel();
-    auto mass = atoms.getMass();
-
-    auto policy = Kokkos::RangePolicy<>(0, numAtoms);
-    auto kernel = KOKKOS_LAMBDA(const idx_t idx)
-    {
-        auto randGen = RNG.get_state();
-        pos(idx, 0) = randGen.drand() * subdomain.diameter[0] + subdomain.minCorner[0];
-        pos(idx, 1) = randGen.drand() * subdomain.diameter[1] + subdomain.minCorner[1];
-        pos(idx, 2) = randGen.drand() * subdomain.diameter[2] + subdomain.minCorner[2];
-
-        vel(idx, 0) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 1) = (randGen.drand() - 0.5_r) * maxVelocity;
-        vel(idx, 2) = (randGen.drand() - 0.5_r) * maxVelocity;
-        RNG.free_state(randGen);
-
-        mass(idx) = 1_r;
-    };
-    Kokkos::parallel_for("fillDomainWithAtomsSC", policy, kernel);
-
-    atoms.numLocalAtoms = numAtoms;
-    atoms.numGhostAtoms = 0;
-    return atoms;
-}
-
 class NVT : public ::testing::TestWithParam<real_t>
 {
 private:
@@ -104,7 +71,7 @@ protected:
 
     data::Subdomain subdomain = { {0_r, 0_r, 0_r}, {Config::Lx, Config::Lx, Config::Lx}, Config::neighborCutoff };
     real_t volume = { subdomain.diameter[0] * subdomain.diameter[1] * subdomain.diameter[2] };
-    data::Atoms atoms = { fillDomainWithAtomsSC(subdomain, idx_c(Config::rho * volume), 1_r) };
+    data::Atoms atoms = { util::fillRectangularDomainWithAtoms(subdomain, idx_c(Config::rho * volume), 1_r, 1_r) };
     real_t rho = { real_c(atoms.numLocalAtoms) / volume };
     communication::GhostLayer ghostLayer;
     action::LennardJones LJ = { Config::rc, Config::sigma, Config::epsilon, 0.7_r * Config::sigma };


### PR DESCRIPTION
Solves #74 

I used the doxygen standard as best I could and recycled much of the code of examples/Argon. I moved the `fillDomainWithAtoms` function to a new file since it reappears in many examples and this way we might avoid the code redundancy while providing test coverage. 