### PR TITLE
avoid relocatable device code

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,7 +42,6 @@ jobs:
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_SERIAL=ON \
             -DKokkos_ENABLE_OPENMP=ON \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
       - name: build dependencies
         run: cmake --build mrmd-build --target gmock gmock_main gtest gtest_main kokkoscontainers kokkoscore kokkossimd yaml-cpp yaml-cpp-parse yaml-cpp-read yaml-cpp-sandbox --parallel 2
@@ -88,7 +87,6 @@ jobs:
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_SERIAL=ON \
             -DKokkos_ENABLE_OPENMP=ON \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
       - name: build dependencies
         run: cmake --build mrmd-build --target gmock gmock_main gtest gtest_main kokkoscontainers kokkoscore kokkossimd yaml-cpp yaml-cpp-parse yaml-cpp-read yaml-cpp-sandbox --parallel 2
@@ -126,7 +124,6 @@ jobs:
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_SERIAL=ON \
             -DKokkos_ENABLE_OPENMP=ON \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
       - name: build dependencies
         run: cmake --build mrmd-build --target gmock gmock_main gtest gtest_main kokkoscontainers kokkoscore kokkossimd yaml-cpp yaml-cpp-parse yaml-cpp-read yaml-cpp-sandbox --parallel 2
@@ -176,9 +173,7 @@ jobs:
             -DKokkos_ENABLE_SERIAL=ON \
             -DKokkos_ENABLE_OPENMP=ON \
             -DKokkos_ENABLE_CUDA=ON \
-            -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON \
             -DKokkos_ARCH_AMPERE80=ON \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
       - name: build dependencies
         run: cmake --build mrmd-build --target gmock gmock_main gtest gtest_main kokkoscontainers kokkoscore kokkossimd yaml-cpp yaml-cpp-parse yaml-cpp-read yaml-cpp-sandbox --parallel 2
@@ -219,7 +214,6 @@ jobs:
             -DKokkos_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK=ON \
             -DKokkos_ENABLE_HWLOC=ON \
             -DKokkos_ENABLE_SERIAL=ON \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 
       - name: run clang-tidy
         working-directory: ./source

--- a/mrmd/action/LennardJones.cpp
+++ b/mrmd/action/LennardJones.cpp
@@ -59,35 +59,6 @@ LennardJones::LennardJones(const std::vector<real_t>& cappingDistance,
 namespace mrmd::action::impl
 {
 KOKKOS_FUNCTION
-CappedLennardJonesPotential::ForceAndEnergy CappedLennardJonesPotential::computeForceAndEnergy(
-    const real_t& distSqr, const idx_t& typeIdx) const
-{
-    ForceAndEnergy ret;
-    if (distSqr >= precomputedValues_(typeIdx).cappingDistanceSqr)
-    {
-        // normal LJ calculation
-        auto frac2 = 1_r / distSqr;
-        auto frac6 = frac2 * frac2 * frac2;
-        ret.forceFactor =
-            frac6 * (precomputedValues_(typeIdx).ff1 * frac6 - precomputedValues_(typeIdx).ff2) *
-            frac2;
-        ret.energy =
-            frac6 * (precomputedValues_(typeIdx).ef1 * frac6 - precomputedValues_(typeIdx).ef2) -
-            precomputedValues_(typeIdx).shift;
-        return ret;
-    }
-
-    // force capping
-    auto dist = std::sqrt(distSqr);
-    ret.forceFactor = precomputedValues_(typeIdx).cappingCoeff / dist;
-    ret.energy = precomputedValues_(typeIdx).energyAtCappingPoint -
-                 (dist - precomputedValues_(typeIdx).cappingDistance) *
-                     precomputedValues_(typeIdx).cappingCoeff -
-                 precomputedValues_(typeIdx).shift;
-    return ret;
-}
-
-KOKKOS_FUNCTION
 void CappedLennardJonesPotential::operator()(const idx_t& typeIdx) const
 {
     // reset capping distance to calculate capping factors with real functions

--- a/mrmd/action/LennardJones.hpp
+++ b/mrmd/action/LennardJones.hpp
@@ -49,8 +49,34 @@ private:
     bool isShifted_;  ///< potential is shifted at rc to 0
 
 public:
-    KOKKOS_FUNCTION
-    ForceAndEnergy computeForceAndEnergy(const real_t& distSqr, const idx_t& typeIdx) const;
+    KOKKOS_INLINE_FUNCTION
+ForceAndEnergy computeForceAndEnergy(
+    const real_t& distSqr, const idx_t& typeIdx) const
+{
+    ForceAndEnergy ret;
+    if (distSqr >= precomputedValues_(typeIdx).cappingDistanceSqr)
+    {
+        // normal LJ calculation
+        auto frac2 = 1_r / distSqr;
+        auto frac6 = frac2 * frac2 * frac2;
+        ret.forceFactor =
+            frac6 * (precomputedValues_(typeIdx).ff1 * frac6 - precomputedValues_(typeIdx).ff2) *
+            frac2;
+        ret.energy =
+            frac6 * (precomputedValues_(typeIdx).ef1 * frac6 - precomputedValues_(typeIdx).ef2) -
+            precomputedValues_(typeIdx).shift;
+        return ret;
+    }
+
+    // force capping
+    auto dist = std::sqrt(distSqr);
+    ret.forceFactor = precomputedValues_(typeIdx).cappingCoeff / dist;
+    ret.energy = precomputedValues_(typeIdx).energyAtCappingPoint -
+                 (dist - precomputedValues_(typeIdx).cappingDistance) *
+                     precomputedValues_(typeIdx).cappingCoeff -
+                 precomputedValues_(typeIdx).shift;
+    return ret;
+}
 
     /**
      * Initialize shift and capping parameters.

--- a/mrmd/action/LennardJones.hpp
+++ b/mrmd/action/LennardJones.hpp
@@ -50,33 +50,32 @@ private:
 
 public:
     KOKKOS_INLINE_FUNCTION
-ForceAndEnergy computeForceAndEnergy(
-    const real_t& distSqr, const idx_t& typeIdx) const
-{
-    ForceAndEnergy ret;
-    if (distSqr >= precomputedValues_(typeIdx).cappingDistanceSqr)
+    ForceAndEnergy computeForceAndEnergy(const real_t& distSqr, const idx_t& typeIdx) const
     {
-        // normal LJ calculation
-        auto frac2 = 1_r / distSqr;
-        auto frac6 = frac2 * frac2 * frac2;
-        ret.forceFactor =
-            frac6 * (precomputedValues_(typeIdx).ff1 * frac6 - precomputedValues_(typeIdx).ff2) *
-            frac2;
-        ret.energy =
-            frac6 * (precomputedValues_(typeIdx).ef1 * frac6 - precomputedValues_(typeIdx).ef2) -
-            precomputedValues_(typeIdx).shift;
+        ForceAndEnergy ret;
+        if (distSqr >= precomputedValues_(typeIdx).cappingDistanceSqr)
+        {
+            // normal LJ calculation
+            auto frac2 = 1_r / distSqr;
+            auto frac6 = frac2 * frac2 * frac2;
+            ret.forceFactor =
+                frac6 *
+                (precomputedValues_(typeIdx).ff1 * frac6 - precomputedValues_(typeIdx).ff2) * frac2;
+            ret.energy = frac6 * (precomputedValues_(typeIdx).ef1 * frac6 -
+                                  precomputedValues_(typeIdx).ef2) -
+                         precomputedValues_(typeIdx).shift;
+            return ret;
+        }
+
+        // force capping
+        auto dist = std::sqrt(distSqr);
+        ret.forceFactor = precomputedValues_(typeIdx).cappingCoeff / dist;
+        ret.energy = precomputedValues_(typeIdx).energyAtCappingPoint -
+                     (dist - precomputedValues_(typeIdx).cappingDistance) *
+                         precomputedValues_(typeIdx).cappingCoeff -
+                     precomputedValues_(typeIdx).shift;
         return ret;
     }
-
-    // force capping
-    auto dist = std::sqrt(distSqr);
-    ret.forceFactor = precomputedValues_(typeIdx).cappingCoeff / dist;
-    ret.energy = precomputedValues_(typeIdx).energyAtCappingPoint -
-                 (dist - precomputedValues_(typeIdx).cappingDistance) *
-                     precomputedValues_(typeIdx).cappingCoeff -
-                 precomputedValues_(typeIdx).shift;
-    return ret;
-}
 
     /**
      * Initialize shift and capping parameters.

--- a/mrmd/action/SPC.hpp
+++ b/mrmd/action/SPC.hpp
@@ -29,9 +29,7 @@ struct Energy
     real_t LJ = 0_r;
     real_t coulomb = 0_r;
 
-    KOKKOS_INLINE_FUNCTION
     Energy() = default;
-    KOKKOS_INLINE_FUNCTION
     Energy(const Energy& rhs) = default;
 
     KOKKOS_INLINE_FUNCTION

--- a/mrmd/communication/MultiResPeriodicGhostExchange.cpp
+++ b/mrmd/communication/MultiResPeriodicGhostExchange.cpp
@@ -27,11 +27,8 @@ struct MoleculesAtomsCounter
     idx_t negativeAtoms = 0;
     idx_t negativeMolecules = 0;
 
-    KOKKOS_INLINE_FUNCTION
     MoleculesAtomsCounter() = default;
-    KOKKOS_INLINE_FUNCTION
     MoleculesAtomsCounter(const MoleculesAtomsCounter& rhs) = default;
-    KOKKOS_INLINE_FUNCTION
     MoleculesAtomsCounter& operator=(const MoleculesAtomsCounter& rhs) = default;
 
     KOKKOS_INLINE_FUNCTION

--- a/mrmd/communication/MultiResPeriodicGhostExchange.hpp
+++ b/mrmd/communication/MultiResPeriodicGhostExchange.hpp
@@ -31,11 +31,9 @@ struct DoubleCounter
     idx_t atoms = 0;
     idx_t molecules = 0;
 
-    KOKKOS_INLINE_FUNCTION
     DoubleCounter() = default;
     KOKKOS_INLINE_FUNCTION
     DoubleCounter(idx_t newAtoms, idx_t newMolecules) : atoms(newAtoms), molecules(newMolecules) {}
-    KOKKOS_INLINE_FUNCTION
     DoubleCounter(const DoubleCounter& rhs) = default;
 
     KOKKOS_INLINE_FUNCTION

--- a/mrmd/data/EnergyAndVirialReducer.hpp
+++ b/mrmd/data/EnergyAndVirialReducer.hpp
@@ -21,11 +21,8 @@ struct EnergyAndVirialReducer
     real_t energy = 0_r;
     real_t virial = 0_r;
 
-    KOKKOS_INLINE_FUNCTION
     EnergyAndVirialReducer() = default;
-    KOKKOS_INLINE_FUNCTION
     EnergyAndVirialReducer(const EnergyAndVirialReducer& rhs) = default;
-    KOKKOS_INLINE_FUNCTION
     EnergyAndVirialReducer& operator=(const EnergyAndVirialReducer& rhs) = default;
 
     KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
Currently the effect is negligible. It improves user experience during build time as less compiler flags are needed.